### PR TITLE
feat: 競馬AI特徴量エンジニアリング Phase1実装（70/100個）

### DIFF
--- a/src/features/extractors/horse_performance.py
+++ b/src/features/extractors/horse_performance.py
@@ -4,22 +4,22 @@
 過去N走の着順、勝率、連対率、複勝率、成績トレンドなど30個の特徴量を抽出。
 """
 
-from typing import Optional
-
 import numpy as np
 import pandas as pd
 from loguru import logger
 
 # from src.core.exceptions import FeatureExtractionError
 
+
 class FeatureExtractionError(Exception):
     """特徴量抽出エラー"""
+
     pass
 
 
 class HorsePerformanceExtractor:
     """馬の成績特徴量を抽出するクラス
-    
+
     Phase1の基本成績特徴量30個を実装。
     過去の着順統計、生涯成績、条件別成績などを計算。
     """
@@ -30,98 +30,96 @@ class HorsePerformanceExtractor:
         self.feature_count = 0
 
     def extract_past_performance_stats(
-        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, history_df: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """過去N走成績統計（15個）
-        
+
         Args:
             df: レースデータ
             history_df: 過去成績データ
-            
+
         Returns:
             特徴量を追加したデータフレーム
         """
         logger.info("過去成績統計特徴量の抽出開始")
         df_features = df.copy()
-        
+
         if history_df is not None and "finish_position" in history_df.columns:
             # 各馬の過去成績を集計
             for horse_id in df["horse_id"].unique():
-                horse_history = history_df[history_df["horse_id"] == horse_id].sort_values(
-                    "race_date", ascending=False
-                )
-                
+                horse_history = history_df[
+                    history_df["horse_id"] == horse_id
+                ].sort_values("race_date", ascending=False)
+
                 # 過去3,5,10走の着順統計
                 for n_races in [3, 5, 10]:
                     recent_races = horse_history.head(n_races)["finish_position"]
-                    
+
                     if len(recent_races) > 0:
                         # 平均着順
                         df_features.loc[
-                            df_features["horse_id"] == horse_id, 
-                            f"avg_finish_position_last{n_races}"
+                            df_features["horse_id"] == horse_id,
+                            f"avg_finish_position_last{n_races}",
                         ] = recent_races.mean()
-                        
+
                         # 中央値
                         df_features.loc[
                             df_features["horse_id"] == horse_id,
-                            f"median_finish_position_last{n_races}"
+                            f"median_finish_position_last{n_races}",
                         ] = recent_races.median()
-                        
+
                         # 標準偏差
                         df_features.loc[
                             df_features["horse_id"] == horse_id,
-                            f"std_finish_position_last{n_races}"
+                            f"std_finish_position_last{n_races}",
                         ] = recent_races.std()
-                        
+
                         # 最高・最低着順
                         if n_races == 5:
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "best_finish_last5"
+                                df_features["horse_id"] == horse_id, "best_finish_last5"
                             ] = recent_races.min()
-                            
+
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "worst_finish_last5"
+                                "worst_finish_last5",
                             ] = recent_races.max()
-                
+
                 # 過去10走の勝利数、連対数、複勝数
                 recent_10 = horse_history.head(10)["finish_position"]
                 if len(recent_10) > 0:
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "win_count_last10"
+                        df_features["horse_id"] == horse_id, "win_count_last10"
                     ] = (recent_10 == 1).sum()
-                    
+
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "place_count_last10"
+                        df_features["horse_id"] == horse_id, "place_count_last10"
                     ] = (recent_10 <= 2).sum()
-                    
+
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "show_count_last10"
+                        df_features["horse_id"] == horse_id, "show_count_last10"
                     ] = (recent_10 <= 3).sum()
-                
+
                 # 着順改善率
                 if len(horse_history) >= 2:
                     recent_positions = horse_history.head(5)["finish_position"].values
                     if len(recent_positions) >= 2:
                         improvements = np.diff(recent_positions) * -1  # 改善はマイナス
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "improvement_rate"
+                            df_features["horse_id"] == horse_id, "improvement_rate"
                         ] = improvements.mean()
-                
+
                 # 安定性スコア（変動係数の逆数）
                 if len(recent_races) >= 3:
-                    cv = recent_races.std() / recent_races.mean() if recent_races.mean() > 0 else 1
+                    cv = (
+                        recent_races.std() / recent_races.mean()
+                        if recent_races.mean() > 0
+                        else 1
+                    )
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "consistency_score"
+                        df_features["horse_id"] == horse_id, "consistency_score"
                     ] = 1 / (1 + cv)
-                
+
                 # 直近調子トレンド（線形回帰の傾き）
                 if len(recent_races) >= 3:
                     x = np.arange(len(recent_races))
@@ -129,339 +127,377 @@ class HorsePerformanceExtractor:
                     if len(x) == len(y):
                         trend = np.polyfit(x, y, 1)[0]
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "recent_form_trend"
+                            df_features["horse_id"] == horse_id, "recent_form_trend"
                         ] = trend * -1  # 改善は正の値
-        
+
         # デフォルト値の設定
         stat_features = [
-            "avg_finish_position_last3", "avg_finish_position_last5", "avg_finish_position_last10",
-            "median_finish_position_last3", "median_finish_position_last5",
-            "std_finish_position_last3", "std_finish_position_last5",
-            "best_finish_last5", "worst_finish_last5",
-            "win_count_last10", "place_count_last10", "show_count_last10",
-            "improvement_rate", "consistency_score", "recent_form_trend"
+            "avg_finish_position_last3",
+            "avg_finish_position_last5",
+            "avg_finish_position_last10",
+            "median_finish_position_last3",
+            "median_finish_position_last5",
+            "std_finish_position_last3",
+            "std_finish_position_last5",
+            "best_finish_last5",
+            "worst_finish_last5",
+            "win_count_last10",
+            "place_count_last10",
+            "show_count_last10",
+            "improvement_rate",
+            "consistency_score",
+            "recent_form_trend",
         ]
-        
+
         for feat in stat_features:
             if feat not in df_features.columns:
                 df_features[feat] = 0
             else:
                 df_features[feat] = df_features[feat].fillna(0)
-        
+
         self.feature_names.extend(stat_features)
         self.feature_count += 15
-        logger.info(f"過去成績統計特徴量15個を追加")
-        
+        logger.info("過去成績統計特徴量15個を追加")
+
         return df_features
 
     def extract_career_performance(
-        self, df: pd.DataFrame, career_df: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, career_df: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """生涯成績特徴量（8個）
-        
+
         Args:
             df: レースデータ
             career_df: 生涯成績データ
-            
+
         Returns:
             特徴量を追加したデータフレーム
         """
         logger.info("生涯成績特徴量の抽出開始")
         df_features = df.copy()
-        
+
         if career_df is not None:
             for horse_id in df["horse_id"].unique():
                 horse_career = career_df[career_df["horse_id"] == horse_id]
-                
+
                 if len(horse_career) > 0:
                     total_starts = len(horse_career)
                     wins = (horse_career["finish_position"] == 1).sum()
                     places = (horse_career["finish_position"] <= 2).sum()
                     shows = (horse_career["finish_position"] <= 3).sum()
-                    
+
                     # 生涯勝率、連対率、複勝率
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "career_win_rate"
+                        df_features["horse_id"] == horse_id, "career_win_rate"
                     ] = wins / total_starts if total_starts > 0 else 0
-                    
+
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "career_place_rate"
+                        df_features["horse_id"] == horse_id, "career_place_rate"
                     ] = places / total_starts if total_starts > 0 else 0
-                    
+
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "career_show_rate"
+                        df_features["horse_id"] == horse_id, "career_show_rate"
                     ] = shows / total_starts if total_starts > 0 else 0
-                    
+
                     # 生涯出走数
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "career_starts"
+                        df_features["horse_id"] == horse_id, "career_starts"
                     ] = total_starts
-                    
+
                     # 生涯獲得賞金
                     if "prize_money" in horse_career.columns:
                         total_earnings = horse_career["prize_money"].sum()
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "career_earnings"
+                            df_features["horse_id"] == horse_id, "career_earnings"
                         ] = total_earnings
-                        
+
                         df_features.loc[
                             df_features["horse_id"] == horse_id,
-                            "career_earnings_per_start"
+                            "career_earnings_per_start",
                         ] = total_earnings / total_starts if total_starts > 0 else 0
-                    
+
                     # G1・重賞勝利数
                     if "race_grade" in horse_career.columns:
                         g1_wins = (
-                            (horse_career["race_grade"] == "G1") & 
-                            (horse_career["finish_position"] == 1)
+                            (horse_career["race_grade"] == "G1")
+                            & (horse_career["finish_position"] == 1)
                         ).sum()
-                        
+
                         graded_wins = (
-                            horse_career["race_grade"].isin(["G1", "G2", "G3"]) & 
-                            (horse_career["finish_position"] == 1)
+                            horse_career["race_grade"].isin(["G1", "G2", "G3"])
+                            & (horse_career["finish_position"] == 1)
                         ).sum()
-                        
+
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "career_g1_wins"
+                            df_features["horse_id"] == horse_id, "career_g1_wins"
                         ] = g1_wins
-                        
+
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "career_graded_wins"
+                            df_features["horse_id"] == horse_id, "career_graded_wins"
                         ] = graded_wins
-        
+
         # デフォルト値の設定
         career_features = [
-            "career_win_rate", "career_place_rate", "career_show_rate",
-            "career_starts", "career_earnings", "career_earnings_per_start",
-            "career_g1_wins", "career_graded_wins"
+            "career_win_rate",
+            "career_place_rate",
+            "career_show_rate",
+            "career_starts",
+            "career_earnings",
+            "career_earnings_per_start",
+            "career_g1_wins",
+            "career_graded_wins",
         ]
-        
+
         for feat in career_features:
             if feat not in df_features.columns:
                 df_features[feat] = 0
             else:
                 df_features[feat] = df_features[feat].fillna(0)
-        
+
         self.feature_names.extend(career_features)
         self.feature_count += 8
-        logger.info(f"生涯成績特徴量8個を追加")
-        
+        logger.info("生涯成績特徴量8個を追加")
+
         return df_features
 
     def extract_conditional_performance(
-        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, history_df: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """条件別成績特徴量（7個）
-        
+
         Args:
             df: レースデータ
             history_df: 過去成績データ（条件情報含む）
-            
+
         Returns:
             特徴量を追加したデータフレーム
         """
         logger.info("条件別成績特徴量の抽出開始")
         df_features = df.copy()
-        
+
         if history_df is not None:
             for horse_id in df["horse_id"].unique():
                 horse_history = history_df[history_df["horse_id"] == horse_id]
-                
+
                 if len(horse_history) > 0:
                     # 距離カテゴリ別勝率
                     if "distance" in horse_history.columns:
                         distance_categories = pd.cut(
                             horse_history["distance"],
                             bins=[0, 1400, 1800, 2200, 4000],
-                            labels=["sprint", "mile", "intermediate", "long"]
+                            labels=["sprint", "mile", "intermediate", "long"],
                         )
-                        
-                        current_distance = df[df["horse_id"] == horse_id]["distance"].iloc[0]
+
+                        current_distance = df[df["horse_id"] == horse_id][
+                            "distance"
+                        ].iloc[0]
                         current_category = pd.cut(
                             [current_distance],
                             bins=[0, 1400, 1800, 2200, 4000],
-                            labels=["sprint", "mile", "intermediate", "long"]
+                            labels=["sprint", "mile", "intermediate", "long"],
                         )[0]
-                        
-                        same_category = horse_history[distance_categories == current_category]
+
+                        same_category = horse_history[
+                            distance_categories == current_category
+                        ]
                         if len(same_category) > 0:
                             win_rate = (same_category["finish_position"] == 1).mean()
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "distance_category_win_rate"
+                                "distance_category_win_rate",
                             ] = win_rate
-                    
+
                     # 馬場状態別勝率
-                    if "track_condition" in horse_history.columns and "track_condition" in df.columns:
-                        current_condition = df[df["horse_id"] == horse_id]["track_condition"].iloc[0]
-                        same_condition = horse_history[horse_history["track_condition"] == current_condition]
+                    if (
+                        "track_condition" in horse_history.columns
+                        and "track_condition" in df.columns
+                    ):
+                        current_condition = df[df["horse_id"] == horse_id][
+                            "track_condition"
+                        ].iloc[0]
+                        same_condition = horse_history[
+                            horse_history["track_condition"] == current_condition
+                        ]
                         if len(same_condition) > 0:
                             win_rate = (same_condition["finish_position"] == 1).mean()
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "track_condition_win_rate"
+                                "track_condition_win_rate",
                             ] = win_rate
-                    
+
                     # 競馬場別勝率
                     if "venue" in horse_history.columns and "venue" in df.columns:
                         current_venue = df[df["horse_id"] == horse_id]["venue"].iloc[0]
-                        same_venue = horse_history[horse_history["venue"] == current_venue]
+                        same_venue = horse_history[
+                            horse_history["venue"] == current_venue
+                        ]
                         if len(same_venue) > 0:
                             win_rate = (same_venue["finish_position"] == 1).mean()
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "venue_win_rate"
+                                df_features["horse_id"] == horse_id, "venue_win_rate"
                             ] = win_rate
-                    
+
                     # クラス別勝率
-                    if "race_class" in horse_history.columns and "race_class" in df.columns:
-                        current_class = df[df["horse_id"] == horse_id]["race_class"].iloc[0]
-                        same_class = horse_history[horse_history["race_class"] == current_class]
+                    if (
+                        "race_class" in horse_history.columns
+                        and "race_class" in df.columns
+                    ):
+                        current_class = df[df["horse_id"] == horse_id][
+                            "race_class"
+                        ].iloc[0]
+                        same_class = horse_history[
+                            horse_history["race_class"] == current_class
+                        ]
                         if len(same_class) > 0:
                             win_rate = (same_class["finish_position"] == 1).mean()
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "class_win_rate"
+                                df_features["horse_id"] == horse_id, "class_win_rate"
                             ] = win_rate
-                    
+
                     # 季節別勝率
                     if "race_date" in horse_history.columns:
                         horse_history["season"] = pd.to_datetime(
                             horse_history["race_date"]
                         ).dt.month.apply(lambda x: (x % 12 + 3) // 3)
-                        
+
                         if "race_date" in df.columns:
                             current_season = pd.to_datetime(
                                 df[df["horse_id"] == horse_id]["race_date"].iloc[0]
                             ).month
                             current_season = (current_season % 12 + 3) // 3
-                            
-                            same_season = horse_history[horse_history["season"] == current_season]
+
+                            same_season = horse_history[
+                                horse_history["season"] == current_season
+                            ]
                             if len(same_season) > 0:
                                 win_rate = (same_season["finish_position"] == 1).mean()
                                 df_features.loc[
                                     df_features["horse_id"] == horse_id,
-                                    "season_win_rate"
+                                    "season_win_rate",
                                 ] = win_rate
-                    
+
                     # 枠順別勝率
                     if "post_position" in horse_history.columns:
                         post_categories = pd.cut(
                             horse_history["post_position"],
                             bins=[0, 4, 12, 20],
-                            labels=["inner", "middle", "outer"]
+                            labels=["inner", "middle", "outer"],
                         )
-                        
+
                         if "post_position" in df.columns:
-                            current_post = df[df["horse_id"] == horse_id]["post_position"].iloc[0]
+                            current_post = df[df["horse_id"] == horse_id][
+                                "post_position"
+                            ].iloc[0]
                             current_post_cat = pd.cut(
                                 [current_post],
                                 bins=[0, 4, 12, 20],
-                                labels=["inner", "middle", "outer"]
+                                labels=["inner", "middle", "outer"],
                             )[0]
-                            
-                            same_post = horse_history[post_categories == current_post_cat]
+
+                            same_post = horse_history[
+                                post_categories == current_post_cat
+                            ]
                             if len(same_post) > 0:
                                 win_rate = (same_post["finish_position"] == 1).mean()
                                 df_features.loc[
                                     df_features["horse_id"] == horse_id,
-                                    "position_win_rate"
+                                    "position_win_rate",
                                 ] = win_rate
-                    
+
                     # 斤量別勝率
                     if "weight_carried" in horse_history.columns:
                         weight_categories = pd.cut(
                             horse_history["weight_carried"],
                             bins=[0, 54, 56, 58, 100],
-                            labels=["light", "standard", "heavy", "very_heavy"]
+                            labels=["light", "standard", "heavy", "very_heavy"],
                         )
-                        
+
                         if "weight_carried" in df.columns:
-                            current_weight = df[df["horse_id"] == horse_id]["weight_carried"].iloc[0]
+                            current_weight = df[df["horse_id"] == horse_id][
+                                "weight_carried"
+                            ].iloc[0]
                             current_weight_cat = pd.cut(
                                 [current_weight],
                                 bins=[0, 54, 56, 58, 100],
-                                labels=["light", "standard", "heavy", "very_heavy"]
+                                labels=["light", "standard", "heavy", "very_heavy"],
                             )[0]
-                            
-                            same_weight = horse_history[weight_categories == current_weight_cat]
+
+                            same_weight = horse_history[
+                                weight_categories == current_weight_cat
+                            ]
                             if len(same_weight) > 0:
                                 win_rate = (same_weight["finish_position"] == 1).mean()
                                 df_features.loc[
                                     df_features["horse_id"] == horse_id,
-                                    "weight_carried_win_rate"
+                                    "weight_carried_win_rate",
                                 ] = win_rate
-        
+
         # デフォルト値の設定
         conditional_features = [
-            "distance_category_win_rate", "track_condition_win_rate",
-            "venue_win_rate", "class_win_rate", "season_win_rate",
-            "position_win_rate", "weight_carried_win_rate"
+            "distance_category_win_rate",
+            "track_condition_win_rate",
+            "venue_win_rate",
+            "class_win_rate",
+            "season_win_rate",
+            "position_win_rate",
+            "weight_carried_win_rate",
         ]
-        
+
         for feat in conditional_features:
             if feat not in df_features.columns:
                 df_features[feat] = 0
             else:
                 df_features[feat] = df_features[feat].fillna(0)
-        
+
         self.feature_names.extend(conditional_features)
         self.feature_count += 7
-        logger.info(f"条件別成績特徴量7個を追加")
-        
+        logger.info("条件別成績特徴量7個を追加")
+
         return df_features
 
     def extract_all_performance_features(
         self,
         df: pd.DataFrame,
-        history_df: Optional[pd.DataFrame] = None,
-        career_df: Optional[pd.DataFrame] = None
+        history_df: pd.DataFrame | None = None,
+        career_df: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         """全成績特徴量を抽出（30個）
-        
+
         Args:
             df: レースデータ
             history_df: 過去成績データ
             career_df: 生涯成績データ
-            
+
         Returns:
             全特徴量を追加したデータフレーム
         """
         logger.info("========== 馬の成績特徴量抽出開始 ==========")
-        
+
         try:
             # 過去N走成績統計（15個）
             df_features = self.extract_past_performance_stats(df, history_df)
-            
+
             # 生涯成績（8個）
             df_features = self.extract_career_performance(df_features, career_df)
-            
+
             # 条件別成績（7個）
             df_features = self.extract_conditional_performance(df_features, history_df)
-            
+
             logger.info(
                 f"✅ 馬の成績特徴量抽出完了: 合計{self.feature_count}個の特徴量を生成"
             )
             logger.info(f"生成された特徴量: {self.feature_names}")
-            
+
             return df_features
-            
+
         except Exception as e:
             raise FeatureExtractionError(
-                f"馬の成績特徴量抽出中にエラーが発生しました: {str(e)}"
+                f"馬の成績特徴量抽出中にエラーが発生しました: {e!s}"
             ) from e
 
     def get_feature_info(self) -> dict[str, any]:
         """特徴量情報の取得
-        
+
         Returns:
             特徴量の情報辞書
         """
@@ -471,6 +507,7 @@ class HorsePerformanceExtractor:
             "categories": {
                 "past_performance": 15,
                 "career_performance": 8,
-                "conditional_performance": 7
-            }
+                "conditional_performance": 7,
+            },
         }
+

--- a/src/features/extractors/horse_performance.py
+++ b/src/features/extractors/horse_performance.py
@@ -1,0 +1,476 @@
+"""馬の成績特徴量抽出モジュール
+
+過去成績から統計的特徴量を生成する。
+過去N走の着順、勝率、連対率、複勝率、成績トレンドなど30個の特徴量を抽出。
+"""
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from loguru import logger
+
+# from src.core.exceptions import FeatureExtractionError
+
+class FeatureExtractionError(Exception):
+    """特徴量抽出エラー"""
+    pass
+
+
+class HorsePerformanceExtractor:
+    """馬の成績特徴量を抽出するクラス
+    
+    Phase1の基本成績特徴量30個を実装。
+    過去の着順統計、生涯成績、条件別成績などを計算。
+    """
+
+    def __init__(self):
+        """初期化"""
+        self.feature_names = []
+        self.feature_count = 0
+
+    def extract_past_performance_stats(
+        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """過去N走成績統計（15個）
+        
+        Args:
+            df: レースデータ
+            history_df: 過去成績データ
+            
+        Returns:
+            特徴量を追加したデータフレーム
+        """
+        logger.info("過去成績統計特徴量の抽出開始")
+        df_features = df.copy()
+        
+        if history_df is not None and "finish_position" in history_df.columns:
+            # 各馬の過去成績を集計
+            for horse_id in df["horse_id"].unique():
+                horse_history = history_df[history_df["horse_id"] == horse_id].sort_values(
+                    "race_date", ascending=False
+                )
+                
+                # 過去3,5,10走の着順統計
+                for n_races in [3, 5, 10]:
+                    recent_races = horse_history.head(n_races)["finish_position"]
+                    
+                    if len(recent_races) > 0:
+                        # 平均着順
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id, 
+                            f"avg_finish_position_last{n_races}"
+                        ] = recent_races.mean()
+                        
+                        # 中央値
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            f"median_finish_position_last{n_races}"
+                        ] = recent_races.median()
+                        
+                        # 標準偏差
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            f"std_finish_position_last{n_races}"
+                        ] = recent_races.std()
+                        
+                        # 最高・最低着順
+                        if n_races == 5:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "best_finish_last5"
+                            ] = recent_races.min()
+                            
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "worst_finish_last5"
+                            ] = recent_races.max()
+                
+                # 過去10走の勝利数、連対数、複勝数
+                recent_10 = horse_history.head(10)["finish_position"]
+                if len(recent_10) > 0:
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "win_count_last10"
+                    ] = (recent_10 == 1).sum()
+                    
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "place_count_last10"
+                    ] = (recent_10 <= 2).sum()
+                    
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "show_count_last10"
+                    ] = (recent_10 <= 3).sum()
+                
+                # 着順改善率
+                if len(horse_history) >= 2:
+                    recent_positions = horse_history.head(5)["finish_position"].values
+                    if len(recent_positions) >= 2:
+                        improvements = np.diff(recent_positions) * -1  # 改善はマイナス
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "improvement_rate"
+                        ] = improvements.mean()
+                
+                # 安定性スコア（変動係数の逆数）
+                if len(recent_races) >= 3:
+                    cv = recent_races.std() / recent_races.mean() if recent_races.mean() > 0 else 1
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "consistency_score"
+                    ] = 1 / (1 + cv)
+                
+                # 直近調子トレンド（線形回帰の傾き）
+                if len(recent_races) >= 3:
+                    x = np.arange(len(recent_races))
+                    y = recent_races.values
+                    if len(x) == len(y):
+                        trend = np.polyfit(x, y, 1)[0]
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "recent_form_trend"
+                        ] = trend * -1  # 改善は正の値
+        
+        # デフォルト値の設定
+        stat_features = [
+            "avg_finish_position_last3", "avg_finish_position_last5", "avg_finish_position_last10",
+            "median_finish_position_last3", "median_finish_position_last5",
+            "std_finish_position_last3", "std_finish_position_last5",
+            "best_finish_last5", "worst_finish_last5",
+            "win_count_last10", "place_count_last10", "show_count_last10",
+            "improvement_rate", "consistency_score", "recent_form_trend"
+        ]
+        
+        for feat in stat_features:
+            if feat not in df_features.columns:
+                df_features[feat] = 0
+            else:
+                df_features[feat] = df_features[feat].fillna(0)
+        
+        self.feature_names.extend(stat_features)
+        self.feature_count += 15
+        logger.info(f"過去成績統計特徴量15個を追加")
+        
+        return df_features
+
+    def extract_career_performance(
+        self, df: pd.DataFrame, career_df: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """生涯成績特徴量（8個）
+        
+        Args:
+            df: レースデータ
+            career_df: 生涯成績データ
+            
+        Returns:
+            特徴量を追加したデータフレーム
+        """
+        logger.info("生涯成績特徴量の抽出開始")
+        df_features = df.copy()
+        
+        if career_df is not None:
+            for horse_id in df["horse_id"].unique():
+                horse_career = career_df[career_df["horse_id"] == horse_id]
+                
+                if len(horse_career) > 0:
+                    total_starts = len(horse_career)
+                    wins = (horse_career["finish_position"] == 1).sum()
+                    places = (horse_career["finish_position"] <= 2).sum()
+                    shows = (horse_career["finish_position"] <= 3).sum()
+                    
+                    # 生涯勝率、連対率、複勝率
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "career_win_rate"
+                    ] = wins / total_starts if total_starts > 0 else 0
+                    
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "career_place_rate"
+                    ] = places / total_starts if total_starts > 0 else 0
+                    
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "career_show_rate"
+                    ] = shows / total_starts if total_starts > 0 else 0
+                    
+                    # 生涯出走数
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "career_starts"
+                    ] = total_starts
+                    
+                    # 生涯獲得賞金
+                    if "prize_money" in horse_career.columns:
+                        total_earnings = horse_career["prize_money"].sum()
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "career_earnings"
+                        ] = total_earnings
+                        
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "career_earnings_per_start"
+                        ] = total_earnings / total_starts if total_starts > 0 else 0
+                    
+                    # G1・重賞勝利数
+                    if "race_grade" in horse_career.columns:
+                        g1_wins = (
+                            (horse_career["race_grade"] == "G1") & 
+                            (horse_career["finish_position"] == 1)
+                        ).sum()
+                        
+                        graded_wins = (
+                            horse_career["race_grade"].isin(["G1", "G2", "G3"]) & 
+                            (horse_career["finish_position"] == 1)
+                        ).sum()
+                        
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "career_g1_wins"
+                        ] = g1_wins
+                        
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "career_graded_wins"
+                        ] = graded_wins
+        
+        # デフォルト値の設定
+        career_features = [
+            "career_win_rate", "career_place_rate", "career_show_rate",
+            "career_starts", "career_earnings", "career_earnings_per_start",
+            "career_g1_wins", "career_graded_wins"
+        ]
+        
+        for feat in career_features:
+            if feat not in df_features.columns:
+                df_features[feat] = 0
+            else:
+                df_features[feat] = df_features[feat].fillna(0)
+        
+        self.feature_names.extend(career_features)
+        self.feature_count += 8
+        logger.info(f"生涯成績特徴量8個を追加")
+        
+        return df_features
+
+    def extract_conditional_performance(
+        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """条件別成績特徴量（7個）
+        
+        Args:
+            df: レースデータ
+            history_df: 過去成績データ（条件情報含む）
+            
+        Returns:
+            特徴量を追加したデータフレーム
+        """
+        logger.info("条件別成績特徴量の抽出開始")
+        df_features = df.copy()
+        
+        if history_df is not None:
+            for horse_id in df["horse_id"].unique():
+                horse_history = history_df[history_df["horse_id"] == horse_id]
+                
+                if len(horse_history) > 0:
+                    # 距離カテゴリ別勝率
+                    if "distance" in horse_history.columns:
+                        distance_categories = pd.cut(
+                            horse_history["distance"],
+                            bins=[0, 1400, 1800, 2200, 4000],
+                            labels=["sprint", "mile", "intermediate", "long"]
+                        )
+                        
+                        current_distance = df[df["horse_id"] == horse_id]["distance"].iloc[0]
+                        current_category = pd.cut(
+                            [current_distance],
+                            bins=[0, 1400, 1800, 2200, 4000],
+                            labels=["sprint", "mile", "intermediate", "long"]
+                        )[0]
+                        
+                        same_category = horse_history[distance_categories == current_category]
+                        if len(same_category) > 0:
+                            win_rate = (same_category["finish_position"] == 1).mean()
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "distance_category_win_rate"
+                            ] = win_rate
+                    
+                    # 馬場状態別勝率
+                    if "track_condition" in horse_history.columns and "track_condition" in df.columns:
+                        current_condition = df[df["horse_id"] == horse_id]["track_condition"].iloc[0]
+                        same_condition = horse_history[horse_history["track_condition"] == current_condition]
+                        if len(same_condition) > 0:
+                            win_rate = (same_condition["finish_position"] == 1).mean()
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "track_condition_win_rate"
+                            ] = win_rate
+                    
+                    # 競馬場別勝率
+                    if "venue" in horse_history.columns and "venue" in df.columns:
+                        current_venue = df[df["horse_id"] == horse_id]["venue"].iloc[0]
+                        same_venue = horse_history[horse_history["venue"] == current_venue]
+                        if len(same_venue) > 0:
+                            win_rate = (same_venue["finish_position"] == 1).mean()
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "venue_win_rate"
+                            ] = win_rate
+                    
+                    # クラス別勝率
+                    if "race_class" in horse_history.columns and "race_class" in df.columns:
+                        current_class = df[df["horse_id"] == horse_id]["race_class"].iloc[0]
+                        same_class = horse_history[horse_history["race_class"] == current_class]
+                        if len(same_class) > 0:
+                            win_rate = (same_class["finish_position"] == 1).mean()
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "class_win_rate"
+                            ] = win_rate
+                    
+                    # 季節別勝率
+                    if "race_date" in horse_history.columns:
+                        horse_history["season"] = pd.to_datetime(
+                            horse_history["race_date"]
+                        ).dt.month.apply(lambda x: (x % 12 + 3) // 3)
+                        
+                        if "race_date" in df.columns:
+                            current_season = pd.to_datetime(
+                                df[df["horse_id"] == horse_id]["race_date"].iloc[0]
+                            ).month
+                            current_season = (current_season % 12 + 3) // 3
+                            
+                            same_season = horse_history[horse_history["season"] == current_season]
+                            if len(same_season) > 0:
+                                win_rate = (same_season["finish_position"] == 1).mean()
+                                df_features.loc[
+                                    df_features["horse_id"] == horse_id,
+                                    "season_win_rate"
+                                ] = win_rate
+                    
+                    # 枠順別勝率
+                    if "post_position" in horse_history.columns:
+                        post_categories = pd.cut(
+                            horse_history["post_position"],
+                            bins=[0, 4, 12, 20],
+                            labels=["inner", "middle", "outer"]
+                        )
+                        
+                        if "post_position" in df.columns:
+                            current_post = df[df["horse_id"] == horse_id]["post_position"].iloc[0]
+                            current_post_cat = pd.cut(
+                                [current_post],
+                                bins=[0, 4, 12, 20],
+                                labels=["inner", "middle", "outer"]
+                            )[0]
+                            
+                            same_post = horse_history[post_categories == current_post_cat]
+                            if len(same_post) > 0:
+                                win_rate = (same_post["finish_position"] == 1).mean()
+                                df_features.loc[
+                                    df_features["horse_id"] == horse_id,
+                                    "position_win_rate"
+                                ] = win_rate
+                    
+                    # 斤量別勝率
+                    if "weight_carried" in horse_history.columns:
+                        weight_categories = pd.cut(
+                            horse_history["weight_carried"],
+                            bins=[0, 54, 56, 58, 100],
+                            labels=["light", "standard", "heavy", "very_heavy"]
+                        )
+                        
+                        if "weight_carried" in df.columns:
+                            current_weight = df[df["horse_id"] == horse_id]["weight_carried"].iloc[0]
+                            current_weight_cat = pd.cut(
+                                [current_weight],
+                                bins=[0, 54, 56, 58, 100],
+                                labels=["light", "standard", "heavy", "very_heavy"]
+                            )[0]
+                            
+                            same_weight = horse_history[weight_categories == current_weight_cat]
+                            if len(same_weight) > 0:
+                                win_rate = (same_weight["finish_position"] == 1).mean()
+                                df_features.loc[
+                                    df_features["horse_id"] == horse_id,
+                                    "weight_carried_win_rate"
+                                ] = win_rate
+        
+        # デフォルト値の設定
+        conditional_features = [
+            "distance_category_win_rate", "track_condition_win_rate",
+            "venue_win_rate", "class_win_rate", "season_win_rate",
+            "position_win_rate", "weight_carried_win_rate"
+        ]
+        
+        for feat in conditional_features:
+            if feat not in df_features.columns:
+                df_features[feat] = 0
+            else:
+                df_features[feat] = df_features[feat].fillna(0)
+        
+        self.feature_names.extend(conditional_features)
+        self.feature_count += 7
+        logger.info(f"条件別成績特徴量7個を追加")
+        
+        return df_features
+
+    def extract_all_performance_features(
+        self,
+        df: pd.DataFrame,
+        history_df: Optional[pd.DataFrame] = None,
+        career_df: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """全成績特徴量を抽出（30個）
+        
+        Args:
+            df: レースデータ
+            history_df: 過去成績データ
+            career_df: 生涯成績データ
+            
+        Returns:
+            全特徴量を追加したデータフレーム
+        """
+        logger.info("========== 馬の成績特徴量抽出開始 ==========")
+        
+        try:
+            # 過去N走成績統計（15個）
+            df_features = self.extract_past_performance_stats(df, history_df)
+            
+            # 生涯成績（8個）
+            df_features = self.extract_career_performance(df_features, career_df)
+            
+            # 条件別成績（7個）
+            df_features = self.extract_conditional_performance(df_features, history_df)
+            
+            logger.info(
+                f"✅ 馬の成績特徴量抽出完了: 合計{self.feature_count}個の特徴量を生成"
+            )
+            logger.info(f"生成された特徴量: {self.feature_names}")
+            
+            return df_features
+            
+        except Exception as e:
+            raise FeatureExtractionError(
+                f"馬の成績特徴量抽出中にエラーが発生しました: {str(e)}"
+            ) from e
+
+    def get_feature_info(self) -> dict[str, any]:
+        """特徴量情報の取得
+        
+        Returns:
+            特徴量の情報辞書
+        """
+        return {
+            "feature_names": self.feature_names,
+            "feature_count": self.feature_count,
+            "categories": {
+                "past_performance": 15,
+                "career_performance": 8,
+                "conditional_performance": 7
+            }
+        }

--- a/src/features/extractors/horse_performance.py
+++ b/src/features/extractors/horse_performance.py
@@ -510,4 +510,3 @@ class HorsePerformanceExtractor:
                 "conditional_performance": 7,
             },
         }
-

--- a/src/features/extractors/jockey_trainer.py
+++ b/src/features/extractors/jockey_trainer.py
@@ -515,4 +515,3 @@ class JockeyTrainerFeatureExtractor:
             "feature_count": self.feature_count,
             "categories": {"jockey": 10, "trainer": 10},
         }
-

--- a/src/features/extractors/jockey_trainer.py
+++ b/src/features/extractors/jockey_trainer.py
@@ -4,22 +4,22 @@
 基本的な騎手・調教師特徴量20個を実装。
 """
 
-from typing import Optional
-
 import numpy as np
 import pandas as pd
 from loguru import logger
 
 # from src.core.exceptions import FeatureExtractionError
 
+
 class FeatureExtractionError(Exception):
     """特徴量抽出エラー"""
+
     pass
 
 
 class JockeyTrainerFeatureExtractor:
     """騎手・調教師特徴量を抽出するクラス
-    
+
     Phase1の騎手・調教師特徴量20個を実装。
     騎手成績、調教師成績、コンビネーション成績などを計算。
     """
@@ -30,102 +30,119 @@ class JockeyTrainerFeatureExtractor:
         self.feature_count = 0
 
     def extract_jockey_features(
-        self, df: pd.DataFrame, jockey_stats: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, jockey_stats: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """騎手特徴量（10個）
-        
+
         Args:
             df: レースデータ
             jockey_stats: 騎手統計データ
-            
+
         Returns:
             特徴量を追加したデータフレーム
         """
         logger.info("騎手特徴量の抽出開始")
         df_features = df.copy()
-        
+
         if jockey_stats is not None and "jockey_id" in df.columns:
             for jockey_id in df["jockey_id"].unique():
                 if pd.isna(jockey_id):
                     continue
-                
+
                 jockey_data = jockey_stats[jockey_stats["jockey_id"] == jockey_id]
-                
+
                 if len(jockey_data) > 0:
                     # 騎手基本成績
                     total_rides = len(jockey_data)
                     wins = (jockey_data["finish_position"] == 1).sum()
                     places = (jockey_data["finish_position"] <= 2).sum()
                     shows = (jockey_data["finish_position"] <= 3).sum()
-                    
+
                     # 騎手勝率・連対率・複勝率
                     df_features.loc[
-                        df_features["jockey_id"] == jockey_id,
-                        "jockey_win_rate"
+                        df_features["jockey_id"] == jockey_id, "jockey_win_rate"
                     ] = wins / total_rides if total_rides > 0 else 0
-                    
+
                     df_features.loc[
-                        df_features["jockey_id"] == jockey_id,
-                        "jockey_place_rate"
+                        df_features["jockey_id"] == jockey_id, "jockey_place_rate"
                     ] = places / total_rides if total_rides > 0 else 0
-                    
+
                     df_features.loc[
-                        df_features["jockey_id"] == jockey_id,
-                        "jockey_show_rate"
+                        df_features["jockey_id"] == jockey_id, "jockey_show_rate"
                     ] = shows / total_rides if total_rides > 0 else 0
-                    
+
                     # 騎手競馬場別勝率
                     if "venue" in df.columns and "venue" in jockey_data.columns:
-                        current_venue = df[df["jockey_id"] == jockey_id]["venue"].iloc[0]
+                        current_venue = df[df["jockey_id"] == jockey_id]["venue"].iloc[
+                            0
+                        ]
                         venue_data = jockey_data[jockey_data["venue"] == current_venue]
                         if len(venue_data) > 0:
                             venue_wins = (venue_data["finish_position"] == 1).sum()
                             df_features.loc[
                                 df_features["jockey_id"] == jockey_id,
-                                "jockey_venue_win_rate"
+                                "jockey_venue_win_rate",
                             ] = venue_wins / len(venue_data)
-                    
+
                     # 騎手距離別勝率
                     if "distance" in df.columns and "distance" in jockey_data.columns:
-                        current_distance = df[df["jockey_id"] == jockey_id]["distance"].iloc[0]
+                        current_distance = df[df["jockey_id"] == jockey_id][
+                            "distance"
+                        ].iloc[0]
                         # 距離カテゴリ分け
-                        distance_category = self._get_distance_category(current_distance)
-                        
+                        distance_category = self._get_distance_category(
+                            current_distance
+                        )
+
                         distance_data = jockey_data[
-                            jockey_data["distance"].apply(self._get_distance_category) == distance_category
+                            jockey_data["distance"].apply(self._get_distance_category)
+                            == distance_category
                         ]
                         if len(distance_data) > 0:
-                            distance_wins = (distance_data["finish_position"] == 1).sum()
+                            distance_wins = (
+                                distance_data["finish_position"] == 1
+                            ).sum()
                             df_features.loc[
                                 df_features["jockey_id"] == jockey_id,
-                                "jockey_distance_win_rate"
+                                "jockey_distance_win_rate",
                             ] = distance_wins / len(distance_data)
-                    
+
                     # 騎手クラス別勝率
-                    if "race_class" in df.columns and "race_class" in jockey_data.columns:
-                        current_class = df[df["jockey_id"] == jockey_id]["race_class"].iloc[0]
-                        class_data = jockey_data[jockey_data["race_class"] == current_class]
+                    if (
+                        "race_class" in df.columns
+                        and "race_class" in jockey_data.columns
+                    ):
+                        current_class = df[df["jockey_id"] == jockey_id][
+                            "race_class"
+                        ].iloc[0]
+                        class_data = jockey_data[
+                            jockey_data["race_class"] == current_class
+                        ]
                         if len(class_data) > 0:
                             class_wins = (class_data["finish_position"] == 1).sum()
                             df_features.loc[
                                 df_features["jockey_id"] == jockey_id,
-                                "jockey_class_win_rate"
+                                "jockey_class_win_rate",
                             ] = class_wins / len(class_data)
-                    
+
                     # 騎手と馬の相性（過去の騎乗成績）
                     if "horse_id" in df.columns and "horse_id" in jockey_data.columns:
-                        for horse_id in df[df["jockey_id"] == jockey_id]["horse_id"].unique():
-                            horse_combo = jockey_data[jockey_data["horse_id"] == horse_id]
+                        for horse_id in df[df["jockey_id"] == jockey_id][
+                            "horse_id"
+                        ].unique():
+                            horse_combo = jockey_data[
+                                jockey_data["horse_id"] == horse_id
+                            ]
                             if len(horse_combo) > 0:
                                 combo_score = self._calculate_compatibility_score(
                                     horse_combo["finish_position"]
                                 )
                                 df_features.loc[
-                                    (df_features["jockey_id"] == jockey_id) & 
-                                    (df_features["horse_id"] == horse_id),
-                                    "jockey_horse_compatibility"
+                                    (df_features["jockey_id"] == jockey_id)
+                                    & (df_features["horse_id"] == horse_id),
+                                    "jockey_horse_compatibility",
                                 ] = combo_score
-                    
+
                     # 騎手直近調子（最近30日の成績）
                     if "race_date" in jockey_data.columns:
                         recent_data = self._get_recent_data(jockey_data, days=30)
@@ -133,9 +150,9 @@ class JockeyTrainerFeatureExtractor:
                             recent_wins = (recent_data["finish_position"] == 1).sum()
                             df_features.loc[
                                 df_features["jockey_id"] == jockey_id,
-                                "jockey_recent_form"
+                                "jockey_recent_form",
                             ] = recent_wins / len(recent_data)
-                    
+
                     # 騎手賞金ランク（年間獲得賞金順位）
                     if "prize_money" in jockey_data.columns:
                         total_earnings = jockey_data["prize_money"].sum()
@@ -143,9 +160,9 @@ class JockeyTrainerFeatureExtractor:
                         earnings_rank = self._get_earnings_rank(total_earnings)
                         df_features.loc[
                             df_features["jockey_id"] == jockey_id,
-                            "jockey_earnings_rank"
+                            "jockey_earnings_rank",
                         ] = earnings_rank
-                    
+
                     # 騎手経験年数（初騎乗からの年数）
                     if "race_date" in jockey_data.columns:
                         first_ride = pd.to_datetime(jockey_data["race_date"]).min()
@@ -153,126 +170,153 @@ class JockeyTrainerFeatureExtractor:
                         experience_years = (latest_ride - first_ride).days / 365.25
                         df_features.loc[
                             df_features["jockey_id"] == jockey_id,
-                            "jockey_experience_years"
+                            "jockey_experience_years",
                         ] = experience_years
-        
+
         # デフォルト値の設定
         jockey_features = [
-            "jockey_win_rate", "jockey_place_rate", "jockey_show_rate",
-            "jockey_venue_win_rate", "jockey_distance_win_rate",
-            "jockey_class_win_rate", "jockey_horse_compatibility",
-            "jockey_recent_form", "jockey_earnings_rank",
-            "jockey_experience_years"
+            "jockey_win_rate",
+            "jockey_place_rate",
+            "jockey_show_rate",
+            "jockey_venue_win_rate",
+            "jockey_distance_win_rate",
+            "jockey_class_win_rate",
+            "jockey_horse_compatibility",
+            "jockey_recent_form",
+            "jockey_earnings_rank",
+            "jockey_experience_years",
         ]
-        
+
         for feat in jockey_features:
             if feat not in df_features.columns:
                 df_features[feat] = 0
             else:
                 df_features[feat] = df_features[feat].fillna(0)
-        
+
         self.feature_names.extend(jockey_features)
         self.feature_count += 10
-        logger.info(f"騎手特徴量10個を追加")
-        
+        logger.info("騎手特徴量10個を追加")
+
         return df_features
 
     def extract_trainer_features(
-        self, df: pd.DataFrame, trainer_stats: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, trainer_stats: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """調教師特徴量（10個）
-        
+
         Args:
             df: レースデータ
             trainer_stats: 調教師統計データ
-            
+
         Returns:
             特徴量を追加したデータフレーム
         """
         logger.info("調教師特徴量の抽出開始")
         df_features = df.copy()
-        
+
         if trainer_stats is not None and "trainer_id" in df.columns:
             for trainer_id in df["trainer_id"].unique():
                 if pd.isna(trainer_id):
                     continue
-                
+
                 trainer_data = trainer_stats[trainer_stats["trainer_id"] == trainer_id]
-                
+
                 if len(trainer_data) > 0:
                     # 調教師基本成績
                     total_horses = len(trainer_data)
                     wins = (trainer_data["finish_position"] == 1).sum()
                     places = (trainer_data["finish_position"] <= 2).sum()
                     shows = (trainer_data["finish_position"] <= 3).sum()
-                    
+
                     # 調教師勝率・連対率・複勝率
                     df_features.loc[
-                        df_features["trainer_id"] == trainer_id,
-                        "trainer_win_rate"
+                        df_features["trainer_id"] == trainer_id, "trainer_win_rate"
                     ] = wins / total_horses if total_horses > 0 else 0
-                    
+
                     df_features.loc[
-                        df_features["trainer_id"] == trainer_id,
-                        "trainer_place_rate"
+                        df_features["trainer_id"] == trainer_id, "trainer_place_rate"
                     ] = places / total_horses if total_horses > 0 else 0
-                    
+
                     df_features.loc[
-                        df_features["trainer_id"] == trainer_id,
-                        "trainer_show_rate"
+                        df_features["trainer_id"] == trainer_id, "trainer_show_rate"
                     ] = shows / total_horses if total_horses > 0 else 0
-                    
+
                     # 調教師競馬場別勝率
                     if "venue" in df.columns and "venue" in trainer_data.columns:
-                        current_venue = df[df["trainer_id"] == trainer_id]["venue"].iloc[0]
-                        venue_data = trainer_data[trainer_data["venue"] == current_venue]
+                        current_venue = df[df["trainer_id"] == trainer_id][
+                            "venue"
+                        ].iloc[0]
+                        venue_data = trainer_data[
+                            trainer_data["venue"] == current_venue
+                        ]
                         if len(venue_data) > 0:
                             venue_wins = (venue_data["finish_position"] == 1).sum()
                             df_features.loc[
                                 df_features["trainer_id"] == trainer_id,
-                                "trainer_venue_win_rate"
+                                "trainer_venue_win_rate",
                             ] = venue_wins / len(venue_data)
-                    
+
                     # 調教師距離別勝率
                     if "distance" in df.columns and "distance" in trainer_data.columns:
-                        current_distance = df[df["trainer_id"] == trainer_id]["distance"].iloc[0]
-                        distance_category = self._get_distance_category(current_distance)
-                        
+                        current_distance = df[df["trainer_id"] == trainer_id][
+                            "distance"
+                        ].iloc[0]
+                        distance_category = self._get_distance_category(
+                            current_distance
+                        )
+
                         distance_data = trainer_data[
-                            trainer_data["distance"].apply(self._get_distance_category) == distance_category
+                            trainer_data["distance"].apply(self._get_distance_category)
+                            == distance_category
                         ]
                         if len(distance_data) > 0:
-                            distance_wins = (distance_data["finish_position"] == 1).sum()
+                            distance_wins = (
+                                distance_data["finish_position"] == 1
+                            ).sum()
                             df_features.loc[
                                 df_features["trainer_id"] == trainer_id,
-                                "trainer_distance_win_rate"
+                                "trainer_distance_win_rate",
                             ] = distance_wins / len(distance_data)
-                    
+
                     # 調教師クラス別勝率
-                    if "race_class" in df.columns and "race_class" in trainer_data.columns:
-                        current_class = df[df["trainer_id"] == trainer_id]["race_class"].iloc[0]
-                        class_data = trainer_data[trainer_data["race_class"] == current_class]
+                    if (
+                        "race_class" in df.columns
+                        and "race_class" in trainer_data.columns
+                    ):
+                        current_class = df[df["trainer_id"] == trainer_id][
+                            "race_class"
+                        ].iloc[0]
+                        class_data = trainer_data[
+                            trainer_data["race_class"] == current_class
+                        ]
                         if len(class_data) > 0:
                             class_wins = (class_data["finish_position"] == 1).sum()
                             df_features.loc[
                                 df_features["trainer_id"] == trainer_id,
-                                "trainer_class_win_rate"
+                                "trainer_class_win_rate",
                             ] = class_wins / len(class_data)
-                    
+
                     # 調教師・騎手コンビ成績
-                    if "jockey_id" in df.columns and "jockey_id" in trainer_data.columns:
-                        for jockey_id in df[df["trainer_id"] == trainer_id]["jockey_id"].unique():
+                    if (
+                        "jockey_id" in df.columns
+                        and "jockey_id" in trainer_data.columns
+                    ):
+                        for jockey_id in df[df["trainer_id"] == trainer_id][
+                            "jockey_id"
+                        ].unique():
                             if pd.isna(jockey_id):
                                 continue
-                            combo_data = trainer_data[trainer_data["jockey_id"] == jockey_id]
+                            combo_data = trainer_data[
+                                trainer_data["jockey_id"] == jockey_id
+                            ]
                             if len(combo_data) > 0:
                                 combo_wins = (combo_data["finish_position"] == 1).sum()
                                 df_features.loc[
-                                    (df_features["trainer_id"] == trainer_id) & 
-                                    (df_features["jockey_id"] == jockey_id),
-                                    "trainer_jockey_combo"
+                                    (df_features["trainer_id"] == trainer_id)
+                                    & (df_features["jockey_id"] == jockey_id),
+                                    "trainer_jockey_combo",
                                 ] = combo_wins / len(combo_data)
-                    
+
                     # 調教師直近調子（最近30日の成績）
                     if "race_date" in trainer_data.columns:
                         recent_data = self._get_recent_data(trainer_data, days=30)
@@ -280,116 +324,119 @@ class JockeyTrainerFeatureExtractor:
                             recent_wins = (recent_data["finish_position"] == 1).sum()
                             df_features.loc[
                                 df_features["trainer_id"] == trainer_id,
-                                "trainer_recent_form"
+                                "trainer_recent_form",
                             ] = recent_wins / len(recent_data)
-                    
+
                     # 厩舎規模（管理馬数）
                     if "horse_id" in trainer_data.columns:
                         unique_horses = trainer_data["horse_id"].nunique()
                         df_features.loc[
                             df_features["trainer_id"] == trainer_id,
-                            "trainer_stable_size"
+                            "trainer_stable_size",
                         ] = unique_horses
-                    
+
                     # 調教師G1勝利数
                     if "race_grade" in trainer_data.columns:
                         g1_wins = (
-                            (trainer_data["race_grade"] == "G1") & 
-                            (trainer_data["finish_position"] == 1)
+                            (trainer_data["race_grade"] == "G1")
+                            & (trainer_data["finish_position"] == 1)
                         ).sum()
                         df_features.loc[
-                            df_features["trainer_id"] == trainer_id,
-                            "trainer_g1_wins"
+                            df_features["trainer_id"] == trainer_id, "trainer_g1_wins"
                         ] = g1_wins
-        
+
         # デフォルト値の設定
         trainer_features = [
-            "trainer_win_rate", "trainer_place_rate", "trainer_show_rate",
-            "trainer_venue_win_rate", "trainer_distance_win_rate",
-            "trainer_class_win_rate", "trainer_jockey_combo",
-            "trainer_recent_form", "trainer_stable_size",
-            "trainer_g1_wins"
+            "trainer_win_rate",
+            "trainer_place_rate",
+            "trainer_show_rate",
+            "trainer_venue_win_rate",
+            "trainer_distance_win_rate",
+            "trainer_class_win_rate",
+            "trainer_jockey_combo",
+            "trainer_recent_form",
+            "trainer_stable_size",
+            "trainer_g1_wins",
         ]
-        
+
         for feat in trainer_features:
             if feat not in df_features.columns:
                 df_features[feat] = 0
             else:
                 df_features[feat] = df_features[feat].fillna(0)
-        
+
         self.feature_names.extend(trainer_features)
         self.feature_count += 10
-        logger.info(f"調教師特徴量10個を追加")
-        
+        logger.info("調教師特徴量10個を追加")
+
         return df_features
 
     def extract_all_jockey_trainer_features(
         self,
         df: pd.DataFrame,
-        jockey_stats: Optional[pd.DataFrame] = None,
-        trainer_stats: Optional[pd.DataFrame] = None
+        jockey_stats: pd.DataFrame | None = None,
+        trainer_stats: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         """全騎手・調教師特徴量を抽出（20個）
-        
+
         Args:
             df: レースデータ
             jockey_stats: 騎手統計データ
             trainer_stats: 調教師統計データ
-            
+
         Returns:
             全特徴量を追加したデータフレーム
         """
         logger.info("========== 騎手・調教師特徴量抽出開始 ==========")
-        
+
         try:
             # 騎手特徴量（10個）
             df_features = self.extract_jockey_features(df, jockey_stats)
-            
+
             # 調教師特徴量（10個）
             df_features = self.extract_trainer_features(df_features, trainer_stats)
-            
+
             logger.info(
                 f"✅ 騎手・調教師特徴量抽出完了: 合計{self.feature_count}個の特徴量を生成"
             )
             logger.info(f"生成された特徴量: {self.feature_names}")
-            
+
             return df_features
-            
+
         except Exception as e:
             raise FeatureExtractionError(
-                f"騎手・調教師特徴量抽出中にエラーが発生しました: {str(e)}"
+                f"騎手・調教師特徴量抽出中にエラーが発生しました: {e!s}"
             ) from e
 
     def _get_distance_category(self, distance: int) -> str:
         """距離をカテゴリに分類
-        
+
         Args:
             distance: 距離（メートル）
-            
+
         Returns:
             距離カテゴリ
         """
         if distance <= 1400:
             return "sprint"
-        elif distance <= 1800:
+        if distance <= 1800:
             return "mile"
-        elif distance <= 2200:
+        if distance <= 2200:
             return "intermediate"
-        else:
-            return "long"
+        return "long"
 
     def _calculate_compatibility_score(self, positions: pd.Series) -> float:
         """相性スコアを計算
-        
+
         Args:
             positions: 着順のシリーズ
-            
+
         Returns:
             相性スコア（0-1）
         """
         if len(positions) == 0:
             return 0
-        
+
         # 着順に応じた重み付けスコア
         scores = []
         for pos in positions:
@@ -405,70 +452,67 @@ class JockeyTrainerFeatureExtractor:
                 scores.append(0.2)
             else:
                 scores.append(0.1)
-        
+
         return np.mean(scores)
 
     def _get_recent_data(self, data: pd.DataFrame, days: int = 30) -> pd.DataFrame:
         """最近のデータを取得
-        
+
         Args:
             data: データフレーム
             days: 取得する日数
-            
+
         Returns:
             最近のデータ
         """
         if "race_date" not in data.columns:
             return pd.DataFrame()
-        
+
         data["race_date"] = pd.to_datetime(data["race_date"])
         latest_date = data["race_date"].max()
         cutoff_date = latest_date - pd.Timedelta(days=days)
-        
+
         return data[data["race_date"] >= cutoff_date]
 
     def _get_earnings_rank(self, total_earnings: float) -> int:
         """獲得賞金からランクを計算
-        
+
         Args:
             total_earnings: 総獲得賞金
-            
+
         Returns:
             ランク（1-10）
         """
         # 簡易的なランク付け（実際は全騎手/調教師での相対順位が必要）
         if total_earnings >= 1000000000:  # 10億円以上
             return 1
-        elif total_earnings >= 500000000:  # 5億円以上
+        if total_earnings >= 500000000:  # 5億円以上
             return 2
-        elif total_earnings >= 200000000:  # 2億円以上
+        if total_earnings >= 200000000:  # 2億円以上
             return 3
-        elif total_earnings >= 100000000:  # 1億円以上
+        if total_earnings >= 100000000:  # 1億円以上
             return 4
-        elif total_earnings >= 50000000:   # 5000万円以上
+        if total_earnings >= 50000000:  # 5000万円以上
             return 5
-        elif total_earnings >= 20000000:   # 2000万円以上
+        if total_earnings >= 20000000:  # 2000万円以上
             return 6
-        elif total_earnings >= 10000000:   # 1000万円以上
+        if total_earnings >= 10000000:  # 1000万円以上
             return 7
-        elif total_earnings >= 5000000:    # 500万円以上
+        if total_earnings >= 5000000:  # 500万円以上
             return 8
-        elif total_earnings >= 1000000:    # 100万円以上
+        if total_earnings >= 1000000:  # 100万円以上
             return 9
-        else:
-            return 10
+        return 10
 
     def get_feature_info(self) -> dict[str, any]:
         """特徴量情報の取得
-        
+
         Returns:
             特徴量の情報辞書
         """
         return {
             "feature_names": self.feature_names,
             "feature_count": self.feature_count,
-            "categories": {
-                "jockey": 10,
-                "trainer": 10
-            }
+            "categories": {"jockey": 10, "trainer": 10},
         }
+

--- a/src/features/extractors/jockey_trainer.py
+++ b/src/features/extractors/jockey_trainer.py
@@ -1,0 +1,474 @@
+"""騎手・調教師特徴量抽出モジュール
+
+騎手と調教師の成績、相性、コンビネーションなどの特徴量を生成する。
+基本的な騎手・調教師特徴量20個を実装。
+"""
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from loguru import logger
+
+# from src.core.exceptions import FeatureExtractionError
+
+class FeatureExtractionError(Exception):
+    """特徴量抽出エラー"""
+    pass
+
+
+class JockeyTrainerFeatureExtractor:
+    """騎手・調教師特徴量を抽出するクラス
+    
+    Phase1の騎手・調教師特徴量20個を実装。
+    騎手成績、調教師成績、コンビネーション成績などを計算。
+    """
+
+    def __init__(self):
+        """初期化"""
+        self.feature_names = []
+        self.feature_count = 0
+
+    def extract_jockey_features(
+        self, df: pd.DataFrame, jockey_stats: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """騎手特徴量（10個）
+        
+        Args:
+            df: レースデータ
+            jockey_stats: 騎手統計データ
+            
+        Returns:
+            特徴量を追加したデータフレーム
+        """
+        logger.info("騎手特徴量の抽出開始")
+        df_features = df.copy()
+        
+        if jockey_stats is not None and "jockey_id" in df.columns:
+            for jockey_id in df["jockey_id"].unique():
+                if pd.isna(jockey_id):
+                    continue
+                
+                jockey_data = jockey_stats[jockey_stats["jockey_id"] == jockey_id]
+                
+                if len(jockey_data) > 0:
+                    # 騎手基本成績
+                    total_rides = len(jockey_data)
+                    wins = (jockey_data["finish_position"] == 1).sum()
+                    places = (jockey_data["finish_position"] <= 2).sum()
+                    shows = (jockey_data["finish_position"] <= 3).sum()
+                    
+                    # 騎手勝率・連対率・複勝率
+                    df_features.loc[
+                        df_features["jockey_id"] == jockey_id,
+                        "jockey_win_rate"
+                    ] = wins / total_rides if total_rides > 0 else 0
+                    
+                    df_features.loc[
+                        df_features["jockey_id"] == jockey_id,
+                        "jockey_place_rate"
+                    ] = places / total_rides if total_rides > 0 else 0
+                    
+                    df_features.loc[
+                        df_features["jockey_id"] == jockey_id,
+                        "jockey_show_rate"
+                    ] = shows / total_rides if total_rides > 0 else 0
+                    
+                    # 騎手競馬場別勝率
+                    if "venue" in df.columns and "venue" in jockey_data.columns:
+                        current_venue = df[df["jockey_id"] == jockey_id]["venue"].iloc[0]
+                        venue_data = jockey_data[jockey_data["venue"] == current_venue]
+                        if len(venue_data) > 0:
+                            venue_wins = (venue_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["jockey_id"] == jockey_id,
+                                "jockey_venue_win_rate"
+                            ] = venue_wins / len(venue_data)
+                    
+                    # 騎手距離別勝率
+                    if "distance" in df.columns and "distance" in jockey_data.columns:
+                        current_distance = df[df["jockey_id"] == jockey_id]["distance"].iloc[0]
+                        # 距離カテゴリ分け
+                        distance_category = self._get_distance_category(current_distance)
+                        
+                        distance_data = jockey_data[
+                            jockey_data["distance"].apply(self._get_distance_category) == distance_category
+                        ]
+                        if len(distance_data) > 0:
+                            distance_wins = (distance_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["jockey_id"] == jockey_id,
+                                "jockey_distance_win_rate"
+                            ] = distance_wins / len(distance_data)
+                    
+                    # 騎手クラス別勝率
+                    if "race_class" in df.columns and "race_class" in jockey_data.columns:
+                        current_class = df[df["jockey_id"] == jockey_id]["race_class"].iloc[0]
+                        class_data = jockey_data[jockey_data["race_class"] == current_class]
+                        if len(class_data) > 0:
+                            class_wins = (class_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["jockey_id"] == jockey_id,
+                                "jockey_class_win_rate"
+                            ] = class_wins / len(class_data)
+                    
+                    # 騎手と馬の相性（過去の騎乗成績）
+                    if "horse_id" in df.columns and "horse_id" in jockey_data.columns:
+                        for horse_id in df[df["jockey_id"] == jockey_id]["horse_id"].unique():
+                            horse_combo = jockey_data[jockey_data["horse_id"] == horse_id]
+                            if len(horse_combo) > 0:
+                                combo_score = self._calculate_compatibility_score(
+                                    horse_combo["finish_position"]
+                                )
+                                df_features.loc[
+                                    (df_features["jockey_id"] == jockey_id) & 
+                                    (df_features["horse_id"] == horse_id),
+                                    "jockey_horse_compatibility"
+                                ] = combo_score
+                    
+                    # 騎手直近調子（最近30日の成績）
+                    if "race_date" in jockey_data.columns:
+                        recent_data = self._get_recent_data(jockey_data, days=30)
+                        if len(recent_data) > 0:
+                            recent_wins = (recent_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["jockey_id"] == jockey_id,
+                                "jockey_recent_form"
+                            ] = recent_wins / len(recent_data)
+                    
+                    # 騎手賞金ランク（年間獲得賞金順位）
+                    if "prize_money" in jockey_data.columns:
+                        total_earnings = jockey_data["prize_money"].sum()
+                        # 簡易的なランク付け（実際は全騎手でのランキングが必要）
+                        earnings_rank = self._get_earnings_rank(total_earnings)
+                        df_features.loc[
+                            df_features["jockey_id"] == jockey_id,
+                            "jockey_earnings_rank"
+                        ] = earnings_rank
+                    
+                    # 騎手経験年数（初騎乗からの年数）
+                    if "race_date" in jockey_data.columns:
+                        first_ride = pd.to_datetime(jockey_data["race_date"]).min()
+                        latest_ride = pd.to_datetime(jockey_data["race_date"]).max()
+                        experience_years = (latest_ride - first_ride).days / 365.25
+                        df_features.loc[
+                            df_features["jockey_id"] == jockey_id,
+                            "jockey_experience_years"
+                        ] = experience_years
+        
+        # デフォルト値の設定
+        jockey_features = [
+            "jockey_win_rate", "jockey_place_rate", "jockey_show_rate",
+            "jockey_venue_win_rate", "jockey_distance_win_rate",
+            "jockey_class_win_rate", "jockey_horse_compatibility",
+            "jockey_recent_form", "jockey_earnings_rank",
+            "jockey_experience_years"
+        ]
+        
+        for feat in jockey_features:
+            if feat not in df_features.columns:
+                df_features[feat] = 0
+            else:
+                df_features[feat] = df_features[feat].fillna(0)
+        
+        self.feature_names.extend(jockey_features)
+        self.feature_count += 10
+        logger.info(f"騎手特徴量10個を追加")
+        
+        return df_features
+
+    def extract_trainer_features(
+        self, df: pd.DataFrame, trainer_stats: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """調教師特徴量（10個）
+        
+        Args:
+            df: レースデータ
+            trainer_stats: 調教師統計データ
+            
+        Returns:
+            特徴量を追加したデータフレーム
+        """
+        logger.info("調教師特徴量の抽出開始")
+        df_features = df.copy()
+        
+        if trainer_stats is not None and "trainer_id" in df.columns:
+            for trainer_id in df["trainer_id"].unique():
+                if pd.isna(trainer_id):
+                    continue
+                
+                trainer_data = trainer_stats[trainer_stats["trainer_id"] == trainer_id]
+                
+                if len(trainer_data) > 0:
+                    # 調教師基本成績
+                    total_horses = len(trainer_data)
+                    wins = (trainer_data["finish_position"] == 1).sum()
+                    places = (trainer_data["finish_position"] <= 2).sum()
+                    shows = (trainer_data["finish_position"] <= 3).sum()
+                    
+                    # 調教師勝率・連対率・複勝率
+                    df_features.loc[
+                        df_features["trainer_id"] == trainer_id,
+                        "trainer_win_rate"
+                    ] = wins / total_horses if total_horses > 0 else 0
+                    
+                    df_features.loc[
+                        df_features["trainer_id"] == trainer_id,
+                        "trainer_place_rate"
+                    ] = places / total_horses if total_horses > 0 else 0
+                    
+                    df_features.loc[
+                        df_features["trainer_id"] == trainer_id,
+                        "trainer_show_rate"
+                    ] = shows / total_horses if total_horses > 0 else 0
+                    
+                    # 調教師競馬場別勝率
+                    if "venue" in df.columns and "venue" in trainer_data.columns:
+                        current_venue = df[df["trainer_id"] == trainer_id]["venue"].iloc[0]
+                        venue_data = trainer_data[trainer_data["venue"] == current_venue]
+                        if len(venue_data) > 0:
+                            venue_wins = (venue_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["trainer_id"] == trainer_id,
+                                "trainer_venue_win_rate"
+                            ] = venue_wins / len(venue_data)
+                    
+                    # 調教師距離別勝率
+                    if "distance" in df.columns and "distance" in trainer_data.columns:
+                        current_distance = df[df["trainer_id"] == trainer_id]["distance"].iloc[0]
+                        distance_category = self._get_distance_category(current_distance)
+                        
+                        distance_data = trainer_data[
+                            trainer_data["distance"].apply(self._get_distance_category) == distance_category
+                        ]
+                        if len(distance_data) > 0:
+                            distance_wins = (distance_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["trainer_id"] == trainer_id,
+                                "trainer_distance_win_rate"
+                            ] = distance_wins / len(distance_data)
+                    
+                    # 調教師クラス別勝率
+                    if "race_class" in df.columns and "race_class" in trainer_data.columns:
+                        current_class = df[df["trainer_id"] == trainer_id]["race_class"].iloc[0]
+                        class_data = trainer_data[trainer_data["race_class"] == current_class]
+                        if len(class_data) > 0:
+                            class_wins = (class_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["trainer_id"] == trainer_id,
+                                "trainer_class_win_rate"
+                            ] = class_wins / len(class_data)
+                    
+                    # 調教師・騎手コンビ成績
+                    if "jockey_id" in df.columns and "jockey_id" in trainer_data.columns:
+                        for jockey_id in df[df["trainer_id"] == trainer_id]["jockey_id"].unique():
+                            if pd.isna(jockey_id):
+                                continue
+                            combo_data = trainer_data[trainer_data["jockey_id"] == jockey_id]
+                            if len(combo_data) > 0:
+                                combo_wins = (combo_data["finish_position"] == 1).sum()
+                                df_features.loc[
+                                    (df_features["trainer_id"] == trainer_id) & 
+                                    (df_features["jockey_id"] == jockey_id),
+                                    "trainer_jockey_combo"
+                                ] = combo_wins / len(combo_data)
+                    
+                    # 調教師直近調子（最近30日の成績）
+                    if "race_date" in trainer_data.columns:
+                        recent_data = self._get_recent_data(trainer_data, days=30)
+                        if len(recent_data) > 0:
+                            recent_wins = (recent_data["finish_position"] == 1).sum()
+                            df_features.loc[
+                                df_features["trainer_id"] == trainer_id,
+                                "trainer_recent_form"
+                            ] = recent_wins / len(recent_data)
+                    
+                    # 厩舎規模（管理馬数）
+                    if "horse_id" in trainer_data.columns:
+                        unique_horses = trainer_data["horse_id"].nunique()
+                        df_features.loc[
+                            df_features["trainer_id"] == trainer_id,
+                            "trainer_stable_size"
+                        ] = unique_horses
+                    
+                    # 調教師G1勝利数
+                    if "race_grade" in trainer_data.columns:
+                        g1_wins = (
+                            (trainer_data["race_grade"] == "G1") & 
+                            (trainer_data["finish_position"] == 1)
+                        ).sum()
+                        df_features.loc[
+                            df_features["trainer_id"] == trainer_id,
+                            "trainer_g1_wins"
+                        ] = g1_wins
+        
+        # デフォルト値の設定
+        trainer_features = [
+            "trainer_win_rate", "trainer_place_rate", "trainer_show_rate",
+            "trainer_venue_win_rate", "trainer_distance_win_rate",
+            "trainer_class_win_rate", "trainer_jockey_combo",
+            "trainer_recent_form", "trainer_stable_size",
+            "trainer_g1_wins"
+        ]
+        
+        for feat in trainer_features:
+            if feat not in df_features.columns:
+                df_features[feat] = 0
+            else:
+                df_features[feat] = df_features[feat].fillna(0)
+        
+        self.feature_names.extend(trainer_features)
+        self.feature_count += 10
+        logger.info(f"調教師特徴量10個を追加")
+        
+        return df_features
+
+    def extract_all_jockey_trainer_features(
+        self,
+        df: pd.DataFrame,
+        jockey_stats: Optional[pd.DataFrame] = None,
+        trainer_stats: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """全騎手・調教師特徴量を抽出（20個）
+        
+        Args:
+            df: レースデータ
+            jockey_stats: 騎手統計データ
+            trainer_stats: 調教師統計データ
+            
+        Returns:
+            全特徴量を追加したデータフレーム
+        """
+        logger.info("========== 騎手・調教師特徴量抽出開始 ==========")
+        
+        try:
+            # 騎手特徴量（10個）
+            df_features = self.extract_jockey_features(df, jockey_stats)
+            
+            # 調教師特徴量（10個）
+            df_features = self.extract_trainer_features(df_features, trainer_stats)
+            
+            logger.info(
+                f"✅ 騎手・調教師特徴量抽出完了: 合計{self.feature_count}個の特徴量を生成"
+            )
+            logger.info(f"生成された特徴量: {self.feature_names}")
+            
+            return df_features
+            
+        except Exception as e:
+            raise FeatureExtractionError(
+                f"騎手・調教師特徴量抽出中にエラーが発生しました: {str(e)}"
+            ) from e
+
+    def _get_distance_category(self, distance: int) -> str:
+        """距離をカテゴリに分類
+        
+        Args:
+            distance: 距離（メートル）
+            
+        Returns:
+            距離カテゴリ
+        """
+        if distance <= 1400:
+            return "sprint"
+        elif distance <= 1800:
+            return "mile"
+        elif distance <= 2200:
+            return "intermediate"
+        else:
+            return "long"
+
+    def _calculate_compatibility_score(self, positions: pd.Series) -> float:
+        """相性スコアを計算
+        
+        Args:
+            positions: 着順のシリーズ
+            
+        Returns:
+            相性スコア（0-1）
+        """
+        if len(positions) == 0:
+            return 0
+        
+        # 着順に応じた重み付けスコア
+        scores = []
+        for pos in positions:
+            if pos == 1:
+                scores.append(1.0)
+            elif pos == 2:
+                scores.append(0.8)
+            elif pos == 3:
+                scores.append(0.6)
+            elif pos <= 5:
+                scores.append(0.4)
+            elif pos <= 10:
+                scores.append(0.2)
+            else:
+                scores.append(0.1)
+        
+        return np.mean(scores)
+
+    def _get_recent_data(self, data: pd.DataFrame, days: int = 30) -> pd.DataFrame:
+        """最近のデータを取得
+        
+        Args:
+            data: データフレーム
+            days: 取得する日数
+            
+        Returns:
+            最近のデータ
+        """
+        if "race_date" not in data.columns:
+            return pd.DataFrame()
+        
+        data["race_date"] = pd.to_datetime(data["race_date"])
+        latest_date = data["race_date"].max()
+        cutoff_date = latest_date - pd.Timedelta(days=days)
+        
+        return data[data["race_date"] >= cutoff_date]
+
+    def _get_earnings_rank(self, total_earnings: float) -> int:
+        """獲得賞金からランクを計算
+        
+        Args:
+            total_earnings: 総獲得賞金
+            
+        Returns:
+            ランク（1-10）
+        """
+        # 簡易的なランク付け（実際は全騎手/調教師での相対順位が必要）
+        if total_earnings >= 1000000000:  # 10億円以上
+            return 1
+        elif total_earnings >= 500000000:  # 5億円以上
+            return 2
+        elif total_earnings >= 200000000:  # 2億円以上
+            return 3
+        elif total_earnings >= 100000000:  # 1億円以上
+            return 4
+        elif total_earnings >= 50000000:   # 5000万円以上
+            return 5
+        elif total_earnings >= 20000000:   # 2000万円以上
+            return 6
+        elif total_earnings >= 10000000:   # 1000万円以上
+            return 7
+        elif total_earnings >= 5000000:    # 500万円以上
+            return 8
+        elif total_earnings >= 1000000:    # 100万円以上
+            return 9
+        else:
+            return 10
+
+    def get_feature_info(self) -> dict[str, any]:
+        """特徴量情報の取得
+        
+        Returns:
+            特徴量の情報辞書
+        """
+        return {
+            "feature_names": self.feature_names,
+            "feature_count": self.feature_count,
+            "categories": {
+                "jockey": 10,
+                "trainer": 10
+            }
+        }

--- a/src/features/extractors/time_features.py
+++ b/src/features/extractors/time_features.py
@@ -521,4 +521,3 @@ class TimeFeatureExtractor:
             "feature_count": self.feature_count,
             "categories": {"race_time": 10, "last_3f": 10},
         }
-

--- a/src/features/extractors/time_features.py
+++ b/src/features/extractors/time_features.py
@@ -1,0 +1,494 @@
+"""タイム特徴量抽出モジュール
+
+走破タイム、上がりタイム、スピード指数など時間関連の特徴量を生成する。
+基本タイム特徴量20個を実装。
+"""
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from loguru import logger
+
+# from src.core.exceptions import FeatureExtractionError
+
+class FeatureExtractionError(Exception):
+    """特徴量抽出エラー"""
+    pass
+
+
+class TimeFeatureExtractor:
+    """タイム特徴量を抽出するクラス
+    
+    Phase1の基本タイム特徴量20個を実装。
+    走破タイム、上がり3F、スピード指数などを計算。
+    """
+
+    def __init__(self):
+        """初期化"""
+        self.feature_names = []
+        self.feature_count = 0
+        
+        # 基準タイム定義（距離別・コース別）
+        self.base_times = {
+            # 芝コース基準タイム（秒）
+            "turf": {
+                1000: 55.0, 1200: 68.0, 1400: 82.0, 1600: 94.0,
+                1800: 107.0, 2000: 120.0, 2200: 133.0, 2400: 146.0,
+                2500: 153.0, 3000: 185.0, 3200: 198.0, 3600: 224.0
+            },
+            # ダートコース基準タイム（秒）
+            "dirt": {
+                1000: 57.0, 1200: 70.0, 1400: 84.0, 1600: 96.0,
+                1700: 103.0, 1800: 110.0, 2000: 123.0, 2100: 130.0,
+                2400: 150.0
+            }
+        }
+
+    def extract_race_time_features(
+        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """走破タイム特徴量（10個）
+        
+        Args:
+            df: レースデータ
+            history_df: 過去成績データ（タイム情報含む）
+            
+        Returns:
+            特徴量を追加したデータフレーム
+        """
+        logger.info("走破タイム特徴量の抽出開始")
+        df_features = df.copy()
+        
+        # 前走タイム
+        if history_df is not None and "race_time" in history_df.columns:
+            for horse_id in df["horse_id"].unique():
+                horse_history = history_df[history_df["horse_id"] == horse_id].sort_values(
+                    "race_date", ascending=False
+                )
+                
+                if len(horse_history) > 0:
+                    # 前走タイム（秒換算）
+                    last_time = self._time_to_seconds(horse_history.iloc[0]["race_time"])
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "last_race_time"
+                    ] = last_time
+                    
+                    # 過去3走・5走平均タイム
+                    for n_races in [3, 5]:
+                        recent_times = horse_history.head(n_races)["race_time"].apply(
+                            self._time_to_seconds
+                        )
+                        if len(recent_times) > 0:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                f"avg_time_last{n_races}"
+                            ] = recent_times.mean()
+                    
+                    # 同距離ベストタイム
+                    if "distance" in df.columns and "distance" in horse_history.columns:
+                        current_distance = df[df["horse_id"] == horse_id]["distance"].iloc[0]
+                        same_distance = horse_history[
+                            horse_history["distance"] == current_distance
+                        ]
+                        if len(same_distance) > 0:
+                            best_time = same_distance["race_time"].apply(
+                                self._time_to_seconds
+                            ).min()
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "best_time_at_distance"
+                            ] = best_time
+                    
+                    # タイム指数（基準タイムとの比較）
+                    if "distance" in df.columns and "track_type" in df.columns:
+                        current_distance = df[df["horse_id"] == horse_id]["distance"].iloc[0]
+                        current_track = df[df["horse_id"] == horse_id]["track_type"].iloc[0]
+                        
+                        base_time = self._get_base_time(current_distance, current_track)
+                        if base_time and last_time:
+                            time_index = (base_time / last_time) * 100
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "time_index"
+                            ] = time_index
+                    
+                    # スピード指数（距離・馬場補正）
+                    if len(horse_history) >= 3:
+                        speed_figures = []
+                        for _, race in horse_history.head(5).iterrows():
+                            if "race_time" in race and "distance" in race:
+                                time_sec = self._time_to_seconds(race["race_time"])
+                                distance = race["distance"]
+                                track = race.get("track_type", "turf")
+                                
+                                # スピード指数 = (距離 / タイム) * 補正係数
+                                if time_sec > 0:
+                                    speed = (distance / time_sec) * self._get_track_correction(track)
+                                    speed_figures.append(speed)
+                        
+                        if speed_figures:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "speed_figure"
+                            ] = np.mean(speed_figures)
+                    
+                    # 基準タイムとの差
+                    if base_time and last_time:
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "time_deviation"
+                        ] = last_time - base_time
+                    
+                    # 距離補正タイム
+                    if "distance" in horse_history.columns:
+                        normalized_times = []
+                        for _, race in horse_history.head(5).iterrows():
+                            if "race_time" in race and "distance" in race:
+                                time_sec = self._time_to_seconds(race["race_time"])
+                                distance = race["distance"]
+                                # 1600mに正規化
+                                normalized_time = time_sec * (1600 / distance)
+                                normalized_times.append(normalized_time)
+                        
+                        if normalized_times:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "normalized_time"
+                            ] = np.mean(normalized_times)
+                    
+                    # 馬場補正タイム
+                    if "track_condition" in horse_history.columns:
+                        adjusted_times = []
+                        for _, race in horse_history.head(5).iterrows():
+                            if "race_time" in race and "track_condition" in race:
+                                time_sec = self._time_to_seconds(race["race_time"])
+                                condition = race["track_condition"]
+                                # 馬場状態による補正
+                                adjusted_time = time_sec * self._get_condition_correction(condition)
+                                adjusted_times.append(adjusted_time)
+                        
+                        if adjusted_times:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "track_adjusted_time"
+                            ] = np.mean(adjusted_times)
+                    
+                    # 相対タイムスコア（同レース内での相対評価）
+                    if "race_id" in horse_history.columns:
+                        relative_scores = []
+                        for race_id in horse_history.head(5)["race_id"]:
+                            race_data = history_df[history_df["race_id"] == race_id]
+                            if len(race_data) > 1:
+                                race_times = race_data["race_time"].apply(self._time_to_seconds)
+                                horse_time = race_data[
+                                    race_data["horse_id"] == horse_id
+                                ]["race_time"].apply(self._time_to_seconds).iloc[0]
+                                
+                                # 相対スコア = (平均タイム / 自身のタイム) * 100
+                                if horse_time > 0:
+                                    relative_score = (race_times.mean() / horse_time) * 100
+                                    relative_scores.append(relative_score)
+                        
+                        if relative_scores:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "relative_time_score"
+                            ] = np.mean(relative_scores)
+        
+        # デフォルト値の設定
+        time_features = [
+            "last_race_time", "avg_time_last3", "avg_time_last5",
+            "best_time_at_distance", "time_index", "speed_figure",
+            "time_deviation", "normalized_time", "track_adjusted_time",
+            "relative_time_score"
+        ]
+        
+        for feat in time_features:
+            if feat not in df_features.columns:
+                df_features[feat] = 0
+            else:
+                df_features[feat] = df_features[feat].fillna(0)
+        
+        self.feature_names.extend(time_features)
+        self.feature_count += 10
+        logger.info(f"走破タイム特徴量10個を追加")
+        
+        return df_features
+
+    def extract_last3f_features(
+        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """上がり3Fタイム特徴量（10個）
+        
+        Args:
+            df: レースデータ
+            history_df: 過去成績データ（上がりタイム情報含む）
+            
+        Returns:
+            特徴量を追加したデータフレーム
+        """
+        logger.info("上がり3Fタイム特徴量の抽出開始")
+        df_features = df.copy()
+        
+        if history_df is not None and "last_3f" in history_df.columns:
+            for horse_id in df["horse_id"].unique():
+                horse_history = history_df[history_df["horse_id"] == horse_id].sort_values(
+                    "race_date", ascending=False
+                )
+                
+                if len(horse_history) > 0:
+                    # 前走上がり3F
+                    last_3f = horse_history.iloc[0]["last_3f"]
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "last_3f_time"
+                    ] = last_3f
+                    
+                    # 過去3走・5走平均上がり3F
+                    for n_races in [3, 5]:
+                        recent_3f = horse_history.head(n_races)["last_3f"]
+                        if len(recent_3f) > 0:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                f"avg_last3f_last{n_races}"
+                            ] = recent_3f.mean()
+                    
+                    # ベスト上がり3F
+                    best_3f = horse_history["last_3f"].min()
+                    df_features.loc[
+                        df_features["horse_id"] == horse_id,
+                        "best_last3f"
+                    ] = best_3f
+                    
+                    # 前走上がり順位
+                    if "last_3f_rank" in horse_history.columns:
+                        last_rank = horse_history.iloc[0]["last_3f_rank"]
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "last3f_rank"
+                        ] = last_rank
+                        
+                        # 平均上がり順位
+                        avg_rank = horse_history.head(5)["last_3f_rank"].mean()
+                        df_features.loc[
+                            df_features["horse_id"] == horse_id,
+                            "avg_last3f_rank"
+                        ] = avg_rank
+                    
+                    # 上がり改善度（直近の変化）
+                    if len(horse_history) >= 2:
+                        recent_3f = horse_history.head(3)["last_3f"].values
+                        if len(recent_3f) >= 2:
+                            improvement = recent_3f[1] - recent_3f[0]  # 改善はマイナス
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "last3f_improvement"
+                            ] = improvement
+                    
+                    # 上がり安定性（変動係数）
+                    if len(horse_history) >= 3:
+                        recent_3f = horse_history.head(5)["last_3f"]
+                        if recent_3f.mean() > 0:
+                            cv = recent_3f.std() / recent_3f.mean()
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "last3f_consistency"
+                            ] = 1 / (1 + cv)  # 安定性スコア
+                    
+                    # 相対上がりタイム（同レース内での比較）
+                    if "race_id" in horse_history.columns:
+                        relative_3f = []
+                        for race_id in horse_history.head(5)["race_id"]:
+                            race_data = history_df[history_df["race_id"] == race_id]
+                            if len(race_data) > 1 and "last_3f" in race_data.columns:
+                                race_3f = race_data["last_3f"]
+                                horse_3f = race_data[
+                                    race_data["horse_id"] == horse_id
+                                ]["last_3f"].iloc[0]
+                                
+                                # 相対値 = 平均との差
+                                relative = race_3f.mean() - horse_3f
+                                relative_3f.append(relative)
+                        
+                        if relative_3f:
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "relative_last3f"
+                            ] = np.mean(relative_3f)
+                    
+                    # 上がりパーセンタイル（全体での位置）
+                    if len(horse_history) >= 10:
+                        all_3f = horse_history["last_3f"].dropna()
+                        if len(all_3f) > 0 and last_3f:
+                            percentile = (all_3f > last_3f).mean() * 100
+                            df_features.loc[
+                                df_features["horse_id"] == horse_id,
+                                "last3f_percentile"
+                            ] = percentile
+        
+        # デフォルト値の設定
+        last3f_features = [
+            "last_3f_time", "avg_last3f_last3", "avg_last3f_last5",
+            "best_last3f", "last3f_rank", "avg_last3f_rank",
+            "last3f_improvement", "last3f_consistency",
+            "relative_last3f", "last3f_percentile"
+        ]
+        
+        for feat in last3f_features:
+            if feat not in df_features.columns:
+                df_features[feat] = 0
+            else:
+                df_features[feat] = df_features[feat].fillna(0)
+        
+        self.feature_names.extend(last3f_features)
+        self.feature_count += 10
+        logger.info(f"上がり3Fタイム特徴量10個を追加")
+        
+        return df_features
+
+    def extract_all_time_features(
+        self,
+        df: pd.DataFrame,
+        history_df: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        """全タイム特徴量を抽出（20個）
+        
+        Args:
+            df: レースデータ
+            history_df: 過去成績データ
+            
+        Returns:
+            全特徴量を追加したデータフレーム
+        """
+        logger.info("========== タイム特徴量抽出開始 ==========")
+        
+        try:
+            # 走破タイム特徴量（10個）
+            df_features = self.extract_race_time_features(df, history_df)
+            
+            # 上がり3Fタイム特徴量（10個）
+            df_features = self.extract_last3f_features(df_features, history_df)
+            
+            logger.info(
+                f"✅ タイム特徴量抽出完了: 合計{self.feature_count}個の特徴量を生成"
+            )
+            logger.info(f"生成された特徴量: {self.feature_names}")
+            
+            return df_features
+            
+        except Exception as e:
+            raise FeatureExtractionError(
+                f"タイム特徴量抽出中にエラーが発生しました: {str(e)}"
+            ) from e
+
+    def _time_to_seconds(self, time_str: str) -> float:
+        """タイム文字列を秒に変換
+        
+        Args:
+            time_str: タイム文字列（例: "1:23.4"）
+            
+        Returns:
+            秒数
+        """
+        if pd.isna(time_str) or time_str == "":
+            return 0
+        
+        try:
+            # "1:23.4" -> 83.4秒
+            if isinstance(time_str, str):
+                if ":" in time_str:
+                    parts = time_str.split(":")
+                    minutes = int(parts[0])
+                    seconds = float(parts[1])
+                    return minutes * 60 + seconds
+                else:
+                    return float(time_str)
+            else:
+                return float(time_str)
+        except:
+            return 0
+
+    def _get_base_time(self, distance: int, track_type: str) -> float:
+        """基準タイムを取得
+        
+        Args:
+            distance: 距離
+            track_type: コース種別（turf/dirt）
+            
+        Returns:
+            基準タイム（秒）
+        """
+        if track_type not in self.base_times:
+            track_type = "turf"  # デフォルト
+        
+        times = self.base_times[track_type]
+        
+        # 最も近い距離の基準タイムを取得
+        if distance in times:
+            return times[distance]
+        else:
+            # 線形補間
+            distances = sorted(times.keys())
+            for i in range(len(distances) - 1):
+                if distances[i] < distance < distances[i + 1]:
+                    d1, d2 = distances[i], distances[i + 1]
+                    t1, t2 = times[d1], times[d2]
+                    # 線形補間
+                    ratio = (distance - d1) / (d2 - d1)
+                    return t1 + ratio * (t2 - t1)
+            
+            # 範囲外の場合は最も近い値
+            if distance < distances[0]:
+                return times[distances[0]]
+            else:
+                return times[distances[-1]]
+
+    def _get_track_correction(self, track_type: str) -> float:
+        """コース種別による補正係数
+        
+        Args:
+            track_type: コース種別
+            
+        Returns:
+            補正係数
+        """
+        corrections = {
+            "turf": 1.0,
+            "dirt": 0.95,  # ダートは少し遅い
+        }
+        return corrections.get(track_type, 1.0)
+
+    def _get_condition_correction(self, condition: str) -> float:
+        """馬場状態による補正係数
+        
+        Args:
+            condition: 馬場状態
+            
+        Returns:
+            補正係数
+        """
+        corrections = {
+            "firm": 0.98,      # 良馬場は速い
+            "good": 1.0,       # 標準
+            "yielding": 1.02,  # 稍重は少し遅い
+            "soft": 1.04,      # 重は遅い
+            "heavy": 1.06,     # 不良は最も遅い
+        }
+        return corrections.get(condition, 1.0)
+
+    def get_feature_info(self) -> dict[str, any]:
+        """特徴量情報の取得
+        
+        Returns:
+            特徴量の情報辞書
+        """
+        return {
+            "feature_names": self.feature_names,
+            "feature_count": self.feature_count,
+            "categories": {
+                "race_time": 10,
+                "last_3f": 10
+            }
+        }

--- a/src/features/extractors/time_features.py
+++ b/src/features/extractors/time_features.py
@@ -4,22 +4,22 @@
 基本タイム特徴量20個を実装。
 """
 
-from typing import Optional
-
 import numpy as np
 import pandas as pd
 from loguru import logger
 
 # from src.core.exceptions import FeatureExtractionError
 
+
 class FeatureExtractionError(Exception):
     """特徴量抽出エラー"""
+
     pass
 
 
 class TimeFeatureExtractor:
     """タイム特徴量を抽出するクラス
-    
+
     Phase1の基本タイム特徴量20個を実装。
     走破タイム、上がり3F、スピード指数などを計算。
     """
@@ -28,53 +28,69 @@ class TimeFeatureExtractor:
         """初期化"""
         self.feature_names = []
         self.feature_count = 0
-        
+
         # 基準タイム定義（距離別・コース別）
         self.base_times = {
             # 芝コース基準タイム（秒）
             "turf": {
-                1000: 55.0, 1200: 68.0, 1400: 82.0, 1600: 94.0,
-                1800: 107.0, 2000: 120.0, 2200: 133.0, 2400: 146.0,
-                2500: 153.0, 3000: 185.0, 3200: 198.0, 3600: 224.0
+                1000: 55.0,
+                1200: 68.0,
+                1400: 82.0,
+                1600: 94.0,
+                1800: 107.0,
+                2000: 120.0,
+                2200: 133.0,
+                2400: 146.0,
+                2500: 153.0,
+                3000: 185.0,
+                3200: 198.0,
+                3600: 224.0,
             },
             # ダートコース基準タイム（秒）
             "dirt": {
-                1000: 57.0, 1200: 70.0, 1400: 84.0, 1600: 96.0,
-                1700: 103.0, 1800: 110.0, 2000: 123.0, 2100: 130.0,
-                2400: 150.0
-            }
+                1000: 57.0,
+                1200: 70.0,
+                1400: 84.0,
+                1600: 96.0,
+                1700: 103.0,
+                1800: 110.0,
+                2000: 123.0,
+                2100: 130.0,
+                2400: 150.0,
+            },
         }
 
     def extract_race_time_features(
-        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, history_df: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """走破タイム特徴量（10個）
-        
+
         Args:
             df: レースデータ
             history_df: 過去成績データ（タイム情報含む）
-            
+
         Returns:
             特徴量を追加したデータフレーム
         """
         logger.info("走破タイム特徴量の抽出開始")
         df_features = df.copy()
-        
+
         # 前走タイム
         if history_df is not None and "race_time" in history_df.columns:
             for horse_id in df["horse_id"].unique():
-                horse_history = history_df[history_df["horse_id"] == horse_id].sort_values(
-                    "race_date", ascending=False
-                )
-                
+                horse_history = history_df[
+                    history_df["horse_id"] == horse_id
+                ].sort_values("race_date", ascending=False)
+
                 if len(horse_history) > 0:
                     # 前走タイム（秒換算）
-                    last_time = self._time_to_seconds(horse_history.iloc[0]["race_time"])
+                    last_time = self._time_to_seconds(
+                        horse_history.iloc[0]["race_time"]
+                    )
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "last_race_time"
+                        df_features["horse_id"] == horse_id, "last_race_time"
                     ] = last_time
-                    
+
                     # 過去3走・5走平均タイム
                     for n_races in [3, 5]:
                         recent_times = horse_history.head(n_races)["race_time"].apply(
@@ -83,37 +99,44 @@ class TimeFeatureExtractor:
                         if len(recent_times) > 0:
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                f"avg_time_last{n_races}"
+                                f"avg_time_last{n_races}",
                             ] = recent_times.mean()
-                    
+
                     # 同距離ベストタイム
                     if "distance" in df.columns and "distance" in horse_history.columns:
-                        current_distance = df[df["horse_id"] == horse_id]["distance"].iloc[0]
+                        current_distance = df[df["horse_id"] == horse_id][
+                            "distance"
+                        ].iloc[0]
                         same_distance = horse_history[
                             horse_history["distance"] == current_distance
                         ]
                         if len(same_distance) > 0:
-                            best_time = same_distance["race_time"].apply(
-                                self._time_to_seconds
-                            ).min()
+                            best_time = (
+                                same_distance["race_time"]
+                                .apply(self._time_to_seconds)
+                                .min()
+                            )
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "best_time_at_distance"
+                                "best_time_at_distance",
                             ] = best_time
-                    
+
                     # タイム指数（基準タイムとの比較）
                     if "distance" in df.columns and "track_type" in df.columns:
-                        current_distance = df[df["horse_id"] == horse_id]["distance"].iloc[0]
-                        current_track = df[df["horse_id"] == horse_id]["track_type"].iloc[0]
-                        
+                        current_distance = df[df["horse_id"] == horse_id][
+                            "distance"
+                        ].iloc[0]
+                        current_track = df[df["horse_id"] == horse_id][
+                            "track_type"
+                        ].iloc[0]
+
                         base_time = self._get_base_time(current_distance, current_track)
                         if base_time and last_time:
                             time_index = (base_time / last_time) * 100
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "time_index"
+                                df_features["horse_id"] == horse_id, "time_index"
                             ] = time_index
-                    
+
                     # スピード指数（距離・馬場補正）
                     if len(horse_history) >= 3:
                         speed_figures = []
@@ -122,25 +145,25 @@ class TimeFeatureExtractor:
                                 time_sec = self._time_to_seconds(race["race_time"])
                                 distance = race["distance"]
                                 track = race.get("track_type", "turf")
-                                
+
                                 # スピード指数 = (距離 / タイム) * 補正係数
                                 if time_sec > 0:
-                                    speed = (distance / time_sec) * self._get_track_correction(track)
+                                    speed = (
+                                        distance / time_sec
+                                    ) * self._get_track_correction(track)
                                     speed_figures.append(speed)
-                        
+
                         if speed_figures:
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "speed_figure"
+                                df_features["horse_id"] == horse_id, "speed_figure"
                             ] = np.mean(speed_figures)
-                    
+
                     # 基準タイムとの差
                     if base_time and last_time:
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "time_deviation"
+                            df_features["horse_id"] == horse_id, "time_deviation"
                         ] = last_time - base_time
-                    
+
                     # 距離補正タイム
                     if "distance" in horse_history.columns:
                         normalized_times = []
@@ -151,13 +174,12 @@ class TimeFeatureExtractor:
                                 # 1600mに正規化
                                 normalized_time = time_sec * (1600 / distance)
                                 normalized_times.append(normalized_time)
-                        
+
                         if normalized_times:
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "normalized_time"
+                                df_features["horse_id"] == horse_id, "normalized_time"
                             ] = np.mean(normalized_times)
-                    
+
                     # 馬場補正タイム
                     if "track_condition" in horse_history.columns:
                         adjusted_times = []
@@ -166,117 +188,129 @@ class TimeFeatureExtractor:
                                 time_sec = self._time_to_seconds(race["race_time"])
                                 condition = race["track_condition"]
                                 # 馬場状態による補正
-                                adjusted_time = time_sec * self._get_condition_correction(condition)
+                                adjusted_time = (
+                                    time_sec * self._get_condition_correction(condition)
+                                )
                                 adjusted_times.append(adjusted_time)
-                        
+
                         if adjusted_times:
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "track_adjusted_time"
+                                "track_adjusted_time",
                             ] = np.mean(adjusted_times)
-                    
+
                     # 相対タイムスコア（同レース内での相対評価）
                     if "race_id" in horse_history.columns:
                         relative_scores = []
                         for race_id in horse_history.head(5)["race_id"]:
                             race_data = history_df[history_df["race_id"] == race_id]
                             if len(race_data) > 1:
-                                race_times = race_data["race_time"].apply(self._time_to_seconds)
-                                horse_time = race_data[
-                                    race_data["horse_id"] == horse_id
-                                ]["race_time"].apply(self._time_to_seconds).iloc[0]
-                                
+                                race_times = race_data["race_time"].apply(
+                                    self._time_to_seconds
+                                )
+                                horse_time = (
+                                    race_data[race_data["horse_id"] == horse_id][
+                                        "race_time"
+                                    ]
+                                    .apply(self._time_to_seconds)
+                                    .iloc[0]
+                                )
+
                                 # 相対スコア = (平均タイム / 自身のタイム) * 100
                                 if horse_time > 0:
-                                    relative_score = (race_times.mean() / horse_time) * 100
+                                    relative_score = (
+                                        race_times.mean() / horse_time
+                                    ) * 100
                                     relative_scores.append(relative_score)
-                        
+
                         if relative_scores:
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "relative_time_score"
+                                "relative_time_score",
                             ] = np.mean(relative_scores)
-        
+
         # デフォルト値の設定
         time_features = [
-            "last_race_time", "avg_time_last3", "avg_time_last5",
-            "best_time_at_distance", "time_index", "speed_figure",
-            "time_deviation", "normalized_time", "track_adjusted_time",
-            "relative_time_score"
+            "last_race_time",
+            "avg_time_last3",
+            "avg_time_last5",
+            "best_time_at_distance",
+            "time_index",
+            "speed_figure",
+            "time_deviation",
+            "normalized_time",
+            "track_adjusted_time",
+            "relative_time_score",
         ]
-        
+
         for feat in time_features:
             if feat not in df_features.columns:
                 df_features[feat] = 0
             else:
                 df_features[feat] = df_features[feat].fillna(0)
-        
+
         self.feature_names.extend(time_features)
         self.feature_count += 10
-        logger.info(f"走破タイム特徴量10個を追加")
-        
+        logger.info("走破タイム特徴量10個を追加")
+
         return df_features
 
     def extract_last3f_features(
-        self, df: pd.DataFrame, history_df: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, history_df: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """上がり3Fタイム特徴量（10個）
-        
+
         Args:
             df: レースデータ
             history_df: 過去成績データ（上がりタイム情報含む）
-            
+
         Returns:
             特徴量を追加したデータフレーム
         """
         logger.info("上がり3Fタイム特徴量の抽出開始")
         df_features = df.copy()
-        
+
         if history_df is not None and "last_3f" in history_df.columns:
             for horse_id in df["horse_id"].unique():
-                horse_history = history_df[history_df["horse_id"] == horse_id].sort_values(
-                    "race_date", ascending=False
-                )
-                
+                horse_history = history_df[
+                    history_df["horse_id"] == horse_id
+                ].sort_values("race_date", ascending=False)
+
                 if len(horse_history) > 0:
                     # 前走上がり3F
                     last_3f = horse_history.iloc[0]["last_3f"]
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "last_3f_time"
+                        df_features["horse_id"] == horse_id, "last_3f_time"
                     ] = last_3f
-                    
+
                     # 過去3走・5走平均上がり3F
                     for n_races in [3, 5]:
                         recent_3f = horse_history.head(n_races)["last_3f"]
                         if len(recent_3f) > 0:
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                f"avg_last3f_last{n_races}"
+                                f"avg_last3f_last{n_races}",
                             ] = recent_3f.mean()
-                    
+
                     # ベスト上がり3F
                     best_3f = horse_history["last_3f"].min()
                     df_features.loc[
-                        df_features["horse_id"] == horse_id,
-                        "best_last3f"
+                        df_features["horse_id"] == horse_id, "best_last3f"
                     ] = best_3f
-                    
+
                     # 前走上がり順位
                     if "last_3f_rank" in horse_history.columns:
                         last_rank = horse_history.iloc[0]["last_3f_rank"]
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "last3f_rank"
+                            df_features["horse_id"] == horse_id, "last3f_rank"
                         ] = last_rank
-                        
+
                         # 平均上がり順位
                         avg_rank = horse_history.head(5)["last_3f_rank"].mean()
                         df_features.loc[
-                            df_features["horse_id"] == horse_id,
-                            "avg_last3f_rank"
+                            df_features["horse_id"] == horse_id, "avg_last3f_rank"
                         ] = avg_rank
-                    
+
                     # 上がり改善度（直近の変化）
                     if len(horse_history) >= 2:
                         recent_3f = horse_history.head(3)["last_3f"].values
@@ -284,9 +318,9 @@ class TimeFeatureExtractor:
                             improvement = recent_3f[1] - recent_3f[0]  # 改善はマイナス
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "last3f_improvement"
+                                "last3f_improvement",
                             ] = improvement
-                    
+
                     # 上がり安定性（変動係数）
                     if len(horse_history) >= 3:
                         recent_3f = horse_history.head(5)["last_3f"]
@@ -294,9 +328,9 @@ class TimeFeatureExtractor:
                             cv = recent_3f.std() / recent_3f.mean()
                             df_features.loc[
                                 df_features["horse_id"] == horse_id,
-                                "last3f_consistency"
+                                "last3f_consistency",
                             ] = 1 / (1 + cv)  # 安定性スコア
-                    
+
                     # 相対上がりタイム（同レース内での比較）
                     if "race_id" in horse_history.columns:
                         relative_3f = []
@@ -304,97 +338,99 @@ class TimeFeatureExtractor:
                             race_data = history_df[history_df["race_id"] == race_id]
                             if len(race_data) > 1 and "last_3f" in race_data.columns:
                                 race_3f = race_data["last_3f"]
-                                horse_3f = race_data[
-                                    race_data["horse_id"] == horse_id
-                                ]["last_3f"].iloc[0]
-                                
+                                horse_3f = race_data[race_data["horse_id"] == horse_id][
+                                    "last_3f"
+                                ].iloc[0]
+
                                 # 相対値 = 平均との差
                                 relative = race_3f.mean() - horse_3f
                                 relative_3f.append(relative)
-                        
+
                         if relative_3f:
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "relative_last3f"
+                                df_features["horse_id"] == horse_id, "relative_last3f"
                             ] = np.mean(relative_3f)
-                    
+
                     # 上がりパーセンタイル（全体での位置）
                     if len(horse_history) >= 10:
                         all_3f = horse_history["last_3f"].dropna()
                         if len(all_3f) > 0 and last_3f:
                             percentile = (all_3f > last_3f).mean() * 100
                             df_features.loc[
-                                df_features["horse_id"] == horse_id,
-                                "last3f_percentile"
+                                df_features["horse_id"] == horse_id, "last3f_percentile"
                             ] = percentile
-        
+
         # デフォルト値の設定
         last3f_features = [
-            "last_3f_time", "avg_last3f_last3", "avg_last3f_last5",
-            "best_last3f", "last3f_rank", "avg_last3f_rank",
-            "last3f_improvement", "last3f_consistency",
-            "relative_last3f", "last3f_percentile"
+            "last_3f_time",
+            "avg_last3f_last3",
+            "avg_last3f_last5",
+            "best_last3f",
+            "last3f_rank",
+            "avg_last3f_rank",
+            "last3f_improvement",
+            "last3f_consistency",
+            "relative_last3f",
+            "last3f_percentile",
         ]
-        
+
         for feat in last3f_features:
             if feat not in df_features.columns:
                 df_features[feat] = 0
             else:
                 df_features[feat] = df_features[feat].fillna(0)
-        
+
         self.feature_names.extend(last3f_features)
         self.feature_count += 10
-        logger.info(f"上がり3Fタイム特徴量10個を追加")
-        
+        logger.info("上がり3Fタイム特徴量10個を追加")
+
         return df_features
 
     def extract_all_time_features(
-        self,
-        df: pd.DataFrame,
-        history_df: Optional[pd.DataFrame] = None
+        self, df: pd.DataFrame, history_df: pd.DataFrame | None = None
     ) -> pd.DataFrame:
         """全タイム特徴量を抽出（20個）
-        
+
         Args:
             df: レースデータ
             history_df: 過去成績データ
-            
+
         Returns:
             全特徴量を追加したデータフレーム
         """
         logger.info("========== タイム特徴量抽出開始 ==========")
-        
+
         try:
             # 走破タイム特徴量（10個）
             df_features = self.extract_race_time_features(df, history_df)
-            
+
             # 上がり3Fタイム特徴量（10個）
             df_features = self.extract_last3f_features(df_features, history_df)
-            
+
             logger.info(
                 f"✅ タイム特徴量抽出完了: 合計{self.feature_count}個の特徴量を生成"
             )
             logger.info(f"生成された特徴量: {self.feature_names}")
-            
+
             return df_features
-            
+
         except Exception as e:
             raise FeatureExtractionError(
-                f"タイム特徴量抽出中にエラーが発生しました: {str(e)}"
+                f"タイム特徴量抽出中にエラーが発生しました: {e!s}"
             ) from e
 
     def _time_to_seconds(self, time_str: str) -> float:
         """タイム文字列を秒に変換
-        
+
         Args:
             time_str: タイム文字列（例: "1:23.4"）
-            
+
         Returns:
             秒数
         """
         if pd.isna(time_str) or time_str == "":
             return 0
-        
+
         try:
             # "1:23.4" -> 83.4秒
             if isinstance(time_str, str):
@@ -403,54 +439,50 @@ class TimeFeatureExtractor:
                     minutes = int(parts[0])
                     seconds = float(parts[1])
                     return minutes * 60 + seconds
-                else:
-                    return float(time_str)
-            else:
                 return float(time_str)
+            return float(time_str)
         except:
             return 0
 
     def _get_base_time(self, distance: int, track_type: str) -> float:
         """基準タイムを取得
-        
+
         Args:
             distance: 距離
             track_type: コース種別（turf/dirt）
-            
+
         Returns:
             基準タイム（秒）
         """
         if track_type not in self.base_times:
             track_type = "turf"  # デフォルト
-        
+
         times = self.base_times[track_type]
-        
+
         # 最も近い距離の基準タイムを取得
         if distance in times:
             return times[distance]
-        else:
-            # 線形補間
-            distances = sorted(times.keys())
-            for i in range(len(distances) - 1):
-                if distances[i] < distance < distances[i + 1]:
-                    d1, d2 = distances[i], distances[i + 1]
-                    t1, t2 = times[d1], times[d2]
-                    # 線形補間
-                    ratio = (distance - d1) / (d2 - d1)
-                    return t1 + ratio * (t2 - t1)
-            
-            # 範囲外の場合は最も近い値
-            if distance < distances[0]:
-                return times[distances[0]]
-            else:
-                return times[distances[-1]]
+        # 線形補間
+        distances = sorted(times.keys())
+        for i in range(len(distances) - 1):
+            if distances[i] < distance < distances[i + 1]:
+                d1, d2 = distances[i], distances[i + 1]
+                t1, t2 = times[d1], times[d2]
+                # 線形補間
+                ratio = (distance - d1) / (d2 - d1)
+                return t1 + ratio * (t2 - t1)
+
+        # 範囲外の場合は最も近い値
+        if distance < distances[0]:
+            return times[distances[0]]
+        return times[distances[-1]]
 
     def _get_track_correction(self, track_type: str) -> float:
         """コース種別による補正係数
-        
+
         Args:
             track_type: コース種別
-            
+
         Returns:
             補正係数
         """
@@ -462,33 +494,31 @@ class TimeFeatureExtractor:
 
     def _get_condition_correction(self, condition: str) -> float:
         """馬場状態による補正係数
-        
+
         Args:
             condition: 馬場状態
-            
+
         Returns:
             補正係数
         """
         corrections = {
-            "firm": 0.98,      # 良馬場は速い
-            "good": 1.0,       # 標準
+            "firm": 0.98,  # 良馬場は速い
+            "good": 1.0,  # 標準
             "yielding": 1.02,  # 稍重は少し遅い
-            "soft": 1.04,      # 重は遅い
-            "heavy": 1.06,     # 不良は最も遅い
+            "soft": 1.04,  # 重は遅い
+            "heavy": 1.06,  # 不良は最も遅い
         }
         return corrections.get(condition, 1.0)
 
     def get_feature_info(self) -> dict[str, any]:
         """特徴量情報の取得
-        
+
         Returns:
             特徴量の情報辞書
         """
         return {
             "feature_names": self.feature_names,
             "feature_count": self.feature_count,
-            "categories": {
-                "race_time": 10,
-                "last_3f": 10
-            }
+            "categories": {"race_time": 10, "last_3f": 10},
         }
+

--- a/tests/unit/features/test_phase1_features.py
+++ b/tests/unit/features/test_phase1_features.py
@@ -20,39 +20,41 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         self.extractor = HorsePerformanceExtractor()
 
         # テスト用レースデータ
-        self.df = pd.DataFrame({
-            "race_id": ["R001", "R001", "R001"],
-            "horse_id": ["H001", "H002", "H003"],
-            "distance": [1600, 1600, 1600],
-            "track_type": ["turf", "turf", "turf"],
-            "track_condition": ["good", "good", "good"],
-            "venue": ["東京", "東京", "東京"],
-            "race_class": ["G1", "G1", "G1"],
-            "race_date": ["2024-01-01", "2024-01-01", "2024-01-01"],
-            "post_position": [1, 5, 10],
-            "weight_carried": [55, 56, 57]
-        })
+        self.df = pd.DataFrame(
+            {
+                "race_id": ["R001", "R001", "R001"],
+                "horse_id": ["H001", "H002", "H003"],
+                "distance": [1600, 1600, 1600],
+                "track_type": ["turf", "turf", "turf"],
+                "track_condition": ["good", "good", "good"],
+                "venue": ["東京", "東京", "東京"],
+                "race_class": ["G1", "G1", "G1"],
+                "race_date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+                "post_position": [1, 5, 10],
+                "weight_carried": [55, 56, 57],
+            }
+        )
 
         # テスト用過去成績データ
-        self.history_df = pd.DataFrame({
-            "horse_id": ["H001"] * 10 + ["H002"] * 10 + ["H003"] * 10,
-            "race_date": pd.date_range("2023-01-01", periods=10).tolist() * 3,
-            "finish_position": [1, 2, 3, 1, 5, 2, 3, 4, 1, 2] * 3,
-            "distance": [1600] * 30,
-            "track_condition": ["good"] * 30,
-            "venue": ["東京"] * 30,
-            "race_class": ["G1"] * 30,
-            "post_position": list(range(1, 11)) * 3,
-            "weight_carried": [55] * 30,
-            "prize_money": [10000000] * 30,
-            "race_grade": ["G1"] * 15 + ["G2"] * 15
-        })
+        self.history_df = pd.DataFrame(
+            {
+                "horse_id": ["H001"] * 10 + ["H002"] * 10 + ["H003"] * 10,
+                "race_date": pd.date_range("2023-01-01", periods=10).tolist() * 3,
+                "finish_position": [1, 2, 3, 1, 5, 2, 3, 4, 1, 2] * 3,
+                "distance": [1600] * 30,
+                "track_condition": ["good"] * 30,
+                "venue": ["東京"] * 30,
+                "race_class": ["G1"] * 30,
+                "post_position": list(range(1, 11)) * 3,
+                "weight_carried": [55] * 30,
+                "prize_money": [10000000] * 30,
+                "race_grade": ["G1"] * 15 + ["G2"] * 15,
+            }
+        )
 
     def test_extract_past_performance_stats(self):
         """過去成績統計特徴量の抽出テスト"""
-        result = self.extractor.extract_past_performance_stats(
-            self.df, self.history_df
-        )
+        result = self.extractor.extract_past_performance_stats(self.df, self.history_df)
 
         # 特徴量が追加されていることを確認
         self.assertIn("avg_finish_position_last3", result.columns)
@@ -65,16 +67,16 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         self.assertIn("recent_form_trend", result.columns)
 
         # 値が数値であることを確認
-        self.assertTrue(pd.api.types.is_numeric_dtype(result["avg_finish_position_last3"]))
+        self.assertTrue(
+            pd.api.types.is_numeric_dtype(result["avg_finish_position_last3"])
+        )
 
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 15)
 
     def test_extract_career_performance(self):
         """生涯成績特徴量の抽出テスト"""
-        result = self.extractor.extract_career_performance(
-            self.df, self.history_df
-        )
+        result = self.extractor.extract_career_performance(self.df, self.history_df)
 
         # 特徴量が追加されていることを確認
         self.assertIn("career_win_rate", result.columns)
@@ -130,26 +132,30 @@ class TestTimeFeatureExtractor(unittest.TestCase):
         self.extractor = TimeFeatureExtractor()
 
         # テスト用レースデータ
-        self.df = pd.DataFrame({
-            "race_id": ["R001", "R001", "R001"],
-            "horse_id": ["H001", "H002", "H003"],
-            "distance": [1600, 1600, 1600],
-            "track_type": ["turf", "turf", "turf"],
-            "track_condition": ["good", "good", "good"]
-        })
+        self.df = pd.DataFrame(
+            {
+                "race_id": ["R001", "R001", "R001"],
+                "horse_id": ["H001", "H002", "H003"],
+                "distance": [1600, 1600, 1600],
+                "track_type": ["turf", "turf", "turf"],
+                "track_condition": ["good", "good", "good"],
+            }
+        )
 
         # テスト用過去成績データ（タイム情報含む）
-        self.history_df = pd.DataFrame({
-            "horse_id": ["H001"] * 5 + ["H002"] * 5 + ["H003"] * 5,
-            "race_id": ["R" + str(i) for i in range(15)],
-            "race_date": pd.date_range("2023-01-01", periods=5).tolist() * 3,
-            "race_time": ["1:33.5", "1:34.0", "1:33.8", "1:34.2", "1:33.6"] * 3,
-            "last_3f": [33.5, 34.0, 33.8, 34.2, 33.6] * 3,
-            "last_3f_rank": [1, 3, 2, 4, 1] * 3,
-            "distance": [1600] * 15,
-            "track_type": ["turf"] * 15,
-            "track_condition": ["good"] * 15
-        })
+        self.history_df = pd.DataFrame(
+            {
+                "horse_id": ["H001"] * 5 + ["H002"] * 5 + ["H003"] * 5,
+                "race_id": ["R" + str(i) for i in range(15)],
+                "race_date": pd.date_range("2023-01-01", periods=5).tolist() * 3,
+                "race_time": ["1:33.5", "1:34.0", "1:33.8", "1:34.2", "1:33.6"] * 3,
+                "last_3f": [33.5, 34.0, 33.8, 34.2, 33.6] * 3,
+                "last_3f_rank": [1, 3, 2, 4, 1] * 3,
+                "distance": [1600] * 15,
+                "track_type": ["turf"] * 15,
+                "track_condition": ["good"] * 15,
+            }
+        )
 
     def test_time_to_seconds_conversion(self):
         """タイム文字列の秒変換テスト"""
@@ -163,9 +169,7 @@ class TestTimeFeatureExtractor(unittest.TestCase):
 
     def test_extract_race_time_features(self):
         """走破タイム特徴量の抽出テスト"""
-        result = self.extractor.extract_race_time_features(
-            self.df, self.history_df
-        )
+        result = self.extractor.extract_race_time_features(self.df, self.history_df)
 
         # 特徴量が追加されていることを確認
         self.assertIn("last_race_time", result.columns)
@@ -180,9 +184,7 @@ class TestTimeFeatureExtractor(unittest.TestCase):
 
     def test_extract_last3f_features(self):
         """上がり3F特徴量の抽出テスト"""
-        result = self.extractor.extract_last3f_features(
-            self.df, self.history_df
-        )
+        result = self.extractor.extract_last3f_features(self.df, self.history_df)
 
         # 特徴量が追加されていることを確認
         self.assertIn("last_3f_time", result.columns)
@@ -217,46 +219,50 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
         self.extractor = JockeyTrainerFeatureExtractor()
 
         # テスト用レースデータ
-        self.df = pd.DataFrame({
-            "race_id": ["R001", "R001", "R001"],
-            "horse_id": ["H001", "H002", "H003"],
-            "jockey_id": ["J001", "J002", "J003"],
-            "trainer_id": ["T001", "T002", "T003"],
-            "distance": [1600, 1600, 1600],
-            "venue": ["東京", "東京", "東京"],
-            "race_class": ["G1", "G1", "G1"]
-        })
+        self.df = pd.DataFrame(
+            {
+                "race_id": ["R001", "R001", "R001"],
+                "horse_id": ["H001", "H002", "H003"],
+                "jockey_id": ["J001", "J002", "J003"],
+                "trainer_id": ["T001", "T002", "T003"],
+                "distance": [1600, 1600, 1600],
+                "venue": ["東京", "東京", "東京"],
+                "race_class": ["G1", "G1", "G1"],
+            }
+        )
 
         # テスト用騎手統計データ
-        self.jockey_stats = pd.DataFrame({
-            "jockey_id": ["J001"] * 20 + ["J002"] * 20 + ["J003"] * 20,
-            "race_date": pd.date_range("2023-01-01", periods=20).tolist() * 3,
-            "finish_position": ([1, 2, 3, 4, 5] * 4) * 3,
-            "distance": [1600] * 60,
-            "venue": ["東京"] * 60,
-            "race_class": ["G1"] * 60,
-            "horse_id": ["H" + str(i % 10) for i in range(60)],
-            "prize_money": [1000000] * 60
-        })
+        self.jockey_stats = pd.DataFrame(
+            {
+                "jockey_id": ["J001"] * 20 + ["J002"] * 20 + ["J003"] * 20,
+                "race_date": pd.date_range("2023-01-01", periods=20).tolist() * 3,
+                "finish_position": ([1, 2, 3, 4, 5] * 4) * 3,
+                "distance": [1600] * 60,
+                "venue": ["東京"] * 60,
+                "race_class": ["G1"] * 60,
+                "horse_id": ["H" + str(i % 10) for i in range(60)],
+                "prize_money": [1000000] * 60,
+            }
+        )
 
         # テスト用調教師統計データ
-        self.trainer_stats = pd.DataFrame({
-            "trainer_id": ["T001"] * 20 + ["T002"] * 20 + ["T003"] * 20,
-            "race_date": pd.date_range("2023-01-01", periods=20).tolist() * 3,
-            "finish_position": ([1, 2, 3, 4, 5] * 4) * 3,
-            "distance": [1600] * 60,
-            "venue": ["東京"] * 60,
-            "race_class": ["G1"] * 60,
-            "jockey_id": ["J" + str(i % 10) for i in range(60)],
-            "horse_id": ["H" + str(i % 10) for i in range(60)],
-            "race_grade": ["G1"] * 30 + ["G2"] * 30
-        })
+        self.trainer_stats = pd.DataFrame(
+            {
+                "trainer_id": ["T001"] * 20 + ["T002"] * 20 + ["T003"] * 20,
+                "race_date": pd.date_range("2023-01-01", periods=20).tolist() * 3,
+                "finish_position": ([1, 2, 3, 4, 5] * 4) * 3,
+                "distance": [1600] * 60,
+                "venue": ["東京"] * 60,
+                "race_class": ["G1"] * 60,
+                "jockey_id": ["J" + str(i % 10) for i in range(60)],
+                "horse_id": ["H" + str(i % 10) for i in range(60)],
+                "race_grade": ["G1"] * 30 + ["G2"] * 30,
+            }
+        )
 
     def test_extract_jockey_features(self):
         """騎手特徴量の抽出テスト"""
-        result = self.extractor.extract_jockey_features(
-            self.df, self.jockey_stats
-        )
+        result = self.extractor.extract_jockey_features(self.df, self.jockey_stats)
 
         # 特徴量が追加されていることを確認
         self.assertIn("jockey_win_rate", result.columns)
@@ -275,9 +281,7 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
 
     def test_extract_trainer_features(self):
         """調教師特徴量の抽出テスト"""
-        result = self.extractor.extract_trainer_features(
-            self.df, self.trainer_stats
-        )
+        result = self.extractor.extract_trainer_features(self.df, self.trainer_stats)
 
         # 特徴量が追加されていることを確認
         self.assertIn("trainer_win_rate", result.columns)
@@ -309,7 +313,7 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
         bad_positions = pd.Series([10, 12, 15])
         self.assertGreater(
             self.extractor._calculate_compatibility_score(good_positions),
-            self.extractor._calculate_compatibility_score(bad_positions)
+            self.extractor._calculate_compatibility_score(bad_positions),
         )
 
 
@@ -324,14 +328,16 @@ class TestFeatureIntegration(unittest.TestCase):
         jt_extractor = JockeyTrainerFeatureExtractor()
 
         # テストデータ作成
-        df = pd.DataFrame({
-            "race_id": ["R001"],
-            "horse_id": ["H001"],
-            "jockey_id": ["J001"],
-            "trainer_id": ["T001"],
-            "distance": [1600],
-            "track_type": ["turf"]
-        })
+        df = pd.DataFrame(
+            {
+                "race_id": ["R001"],
+                "horse_id": ["H001"],
+                "jockey_id": ["J001"],
+                "trainer_id": ["T001"],
+                "distance": [1600],
+                "track_type": ["turf"],
+            }
+        )
 
         # 各特徴量抽出
         df = perf_extractor.extract_all_performance_features(df)
@@ -340,9 +346,9 @@ class TestFeatureIntegration(unittest.TestCase):
 
         # 合計70個の特徴量が生成されることを確認
         total_features = (
-            perf_extractor.feature_count +
-            time_extractor.feature_count +
-            jt_extractor.feature_count
+            perf_extractor.feature_count
+            + time_extractor.feature_count
+            + jt_extractor.feature_count
         )
         self.assertEqual(total_features, 70)
 

--- a/tests/unit/features/test_phase1_features.py
+++ b/tests/unit/features/test_phase1_features.py
@@ -4,9 +4,7 @@
 """
 
 import unittest
-from datetime import datetime, timedelta
 
-import numpy as np
 import pandas as pd
 
 from src.features.extractors.horse_performance import HorsePerformanceExtractor
@@ -20,7 +18,7 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
     def setUp(self):
         """テストデータのセットアップ"""
         self.extractor = HorsePerformanceExtractor()
-        
+
         # テスト用レースデータ
         self.df = pd.DataFrame({
             "race_id": ["R001", "R001", "R001"],
@@ -34,7 +32,7 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
             "post_position": [1, 5, 10],
             "weight_carried": [55, 56, 57]
         })
-        
+
         # テスト用過去成績データ
         self.history_df = pd.DataFrame({
             "horse_id": ["H001"] * 10 + ["H002"] * 10 + ["H003"] * 10,
@@ -55,7 +53,7 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         result = self.extractor.extract_past_performance_stats(
             self.df, self.history_df
         )
-        
+
         # 特徴量が追加されていることを確認
         self.assertIn("avg_finish_position_last3", result.columns)
         self.assertIn("median_finish_position_last5", result.columns)
@@ -65,10 +63,10 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         self.assertIn("win_count_last10", result.columns)
         self.assertIn("consistency_score", result.columns)
         self.assertIn("recent_form_trend", result.columns)
-        
+
         # 値が数値であることを確認
         self.assertTrue(pd.api.types.is_numeric_dtype(result["avg_finish_position_last3"]))
-        
+
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 15)
 
@@ -77,7 +75,7 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         result = self.extractor.extract_career_performance(
             self.df, self.history_df
         )
-        
+
         # 特徴量が追加されていることを確認
         self.assertIn("career_win_rate", result.columns)
         self.assertIn("career_place_rate", result.columns)
@@ -85,11 +83,11 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         self.assertIn("career_starts", result.columns)
         self.assertIn("career_earnings", result.columns)
         self.assertIn("career_g1_wins", result.columns)
-        
+
         # 勝率が0-1の範囲内であることを確認
         self.assertTrue((result["career_win_rate"] >= 0).all())
         self.assertTrue((result["career_win_rate"] <= 1).all())
-        
+
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 8)
 
@@ -98,14 +96,14 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         result = self.extractor.extract_conditional_performance(
             self.df, self.history_df
         )
-        
+
         # 特徴量が追加されていることを確認
         self.assertIn("distance_category_win_rate", result.columns)
         self.assertIn("track_condition_win_rate", result.columns)
         self.assertIn("venue_win_rate", result.columns)
         self.assertIn("class_win_rate", result.columns)
         self.assertIn("position_win_rate", result.columns)
-        
+
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 7)
 
@@ -114,11 +112,11 @@ class TestHorsePerformanceExtractor(unittest.TestCase):
         result = self.extractor.extract_all_performance_features(
             self.df, self.history_df, self.history_df
         )
-        
+
         # 全30個の特徴量が生成されることを確認
         self.assertEqual(self.extractor.feature_count, 30)
         self.assertEqual(len(self.extractor.feature_names), 30)
-        
+
         # NaN値がないことを確認（デフォルト値0で埋められている）
         for feat in self.extractor.feature_names:
             self.assertFalse(result[feat].isna().any())
@@ -130,7 +128,7 @@ class TestTimeFeatureExtractor(unittest.TestCase):
     def setUp(self):
         """テストデータのセットアップ"""
         self.extractor = TimeFeatureExtractor()
-        
+
         # テスト用レースデータ
         self.df = pd.DataFrame({
             "race_id": ["R001", "R001", "R001"],
@@ -139,7 +137,7 @@ class TestTimeFeatureExtractor(unittest.TestCase):
             "track_type": ["turf", "turf", "turf"],
             "track_condition": ["good", "good", "good"]
         })
-        
+
         # テスト用過去成績データ（タイム情報含む）
         self.history_df = pd.DataFrame({
             "horse_id": ["H001"] * 5 + ["H002"] * 5 + ["H003"] * 5,
@@ -158,7 +156,7 @@ class TestTimeFeatureExtractor(unittest.TestCase):
         # 正常なケース
         self.assertEqual(self.extractor._time_to_seconds("1:33.5"), 93.5)
         self.assertEqual(self.extractor._time_to_seconds("2:01.2"), 121.2)
-        
+
         # エッジケース
         self.assertEqual(self.extractor._time_to_seconds(""), 0)
         self.assertEqual(self.extractor._time_to_seconds(None), 0)
@@ -168,7 +166,7 @@ class TestTimeFeatureExtractor(unittest.TestCase):
         result = self.extractor.extract_race_time_features(
             self.df, self.history_df
         )
-        
+
         # 特徴量が追加されていることを確認
         self.assertIn("last_race_time", result.columns)
         self.assertIn("avg_time_last3", result.columns)
@@ -176,7 +174,7 @@ class TestTimeFeatureExtractor(unittest.TestCase):
         self.assertIn("best_time_at_distance", result.columns)
         self.assertIn("time_index", result.columns)
         self.assertIn("speed_figure", result.columns)
-        
+
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 10)
 
@@ -185,14 +183,14 @@ class TestTimeFeatureExtractor(unittest.TestCase):
         result = self.extractor.extract_last3f_features(
             self.df, self.history_df
         )
-        
+
         # 特徴量が追加されていることを確認
         self.assertIn("last_3f_time", result.columns)
         self.assertIn("avg_last3f_last3", result.columns)
         self.assertIn("best_last3f", result.columns)
         self.assertIn("last3f_rank", result.columns)
         self.assertIn("last3f_consistency", result.columns)
-        
+
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 10)
 
@@ -201,11 +199,11 @@ class TestTimeFeatureExtractor(unittest.TestCase):
         # 芝1600m
         base_time = self.extractor._get_base_time(1600, "turf")
         self.assertEqual(base_time, 94.0)
-        
+
         # ダート1800m
         base_time = self.extractor._get_base_time(1800, "dirt")
         self.assertEqual(base_time, 110.0)
-        
+
         # 中間距離の補間
         base_time = self.extractor._get_base_time(1700, "turf")
         self.assertTrue(94.0 < base_time < 107.0)
@@ -217,7 +215,7 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
     def setUp(self):
         """テストデータのセットアップ"""
         self.extractor = JockeyTrainerFeatureExtractor()
-        
+
         # テスト用レースデータ
         self.df = pd.DataFrame({
             "race_id": ["R001", "R001", "R001"],
@@ -228,7 +226,7 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
             "venue": ["東京", "東京", "東京"],
             "race_class": ["G1", "G1", "G1"]
         })
-        
+
         # テスト用騎手統計データ
         self.jockey_stats = pd.DataFrame({
             "jockey_id": ["J001"] * 20 + ["J002"] * 20 + ["J003"] * 20,
@@ -240,7 +238,7 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
             "horse_id": ["H" + str(i % 10) for i in range(60)],
             "prize_money": [1000000] * 60
         })
-        
+
         # テスト用調教師統計データ
         self.trainer_stats = pd.DataFrame({
             "trainer_id": ["T001"] * 20 + ["T002"] * 20 + ["T003"] * 20,
@@ -259,7 +257,7 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
         result = self.extractor.extract_jockey_features(
             self.df, self.jockey_stats
         )
-        
+
         # 特徴量が追加されていることを確認
         self.assertIn("jockey_win_rate", result.columns)
         self.assertIn("jockey_place_rate", result.columns)
@@ -267,11 +265,11 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
         self.assertIn("jockey_venue_win_rate", result.columns)
         self.assertIn("jockey_distance_win_rate", result.columns)
         self.assertIn("jockey_experience_years", result.columns)
-        
+
         # 勝率が0-1の範囲内であることを確認
         self.assertTrue((result["jockey_win_rate"] >= 0).all())
         self.assertTrue((result["jockey_win_rate"] <= 1).all())
-        
+
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 10)
 
@@ -280,14 +278,14 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
         result = self.extractor.extract_trainer_features(
             self.df, self.trainer_stats
         )
-        
+
         # 特徴量が追加されていることを確認
         self.assertIn("trainer_win_rate", result.columns)
         self.assertIn("trainer_place_rate", result.columns)
         self.assertIn("trainer_venue_win_rate", result.columns)
         self.assertIn("trainer_stable_size", result.columns)
         self.assertIn("trainer_g1_wins", result.columns)
-        
+
         # 特徴量数の確認
         self.assertEqual(self.extractor.feature_count, 10)
 
@@ -302,10 +300,10 @@ class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
         """相性スコア計算のテスト"""
         positions = pd.Series([1, 2, 3, 4, 5])
         score = self.extractor._calculate_compatibility_score(positions)
-        
+
         # スコアが0-1の範囲内であることを確認
         self.assertTrue(0 <= score <= 1)
-        
+
         # 良い成績ほど高スコア
         good_positions = pd.Series([1, 1, 2])
         bad_positions = pd.Series([10, 12, 15])
@@ -324,7 +322,7 @@ class TestFeatureIntegration(unittest.TestCase):
         perf_extractor = HorsePerformanceExtractor()
         time_extractor = TimeFeatureExtractor()
         jt_extractor = JockeyTrainerFeatureExtractor()
-        
+
         # テストデータ作成
         df = pd.DataFrame({
             "race_id": ["R001"],
@@ -334,12 +332,12 @@ class TestFeatureIntegration(unittest.TestCase):
             "distance": [1600],
             "track_type": ["turf"]
         })
-        
+
         # 各特徴量抽出
         df = perf_extractor.extract_all_performance_features(df)
         df = time_extractor.extract_all_time_features(df)
         df = jt_extractor.extract_all_jockey_trainer_features(df)
-        
+
         # 合計70個の特徴量が生成されることを確認
         total_features = (
             perf_extractor.feature_count +
@@ -347,7 +345,7 @@ class TestFeatureIntegration(unittest.TestCase):
             jt_extractor.feature_count
         )
         self.assertEqual(total_features, 70)
-        
+
         print(f"✅ Phase1特徴量テスト完了: 合計{total_features}個の特徴量を確認")
 
 

--- a/tests/unit/features/test_phase1_features.py
+++ b/tests/unit/features/test_phase1_features.py
@@ -1,0 +1,355 @@
+"""Phase1特徴量抽出器のユニットテスト
+
+基本成績、タイム、騎手・調教師特徴量のテストを実装。
+"""
+
+import unittest
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+
+from src.features.extractors.horse_performance import HorsePerformanceExtractor
+from src.features.extractors.jockey_trainer import JockeyTrainerFeatureExtractor
+from src.features.extractors.time_features import TimeFeatureExtractor
+
+
+class TestHorsePerformanceExtractor(unittest.TestCase):
+    """馬の成績特徴量抽出器のテスト"""
+
+    def setUp(self):
+        """テストデータのセットアップ"""
+        self.extractor = HorsePerformanceExtractor()
+        
+        # テスト用レースデータ
+        self.df = pd.DataFrame({
+            "race_id": ["R001", "R001", "R001"],
+            "horse_id": ["H001", "H002", "H003"],
+            "distance": [1600, 1600, 1600],
+            "track_type": ["turf", "turf", "turf"],
+            "track_condition": ["good", "good", "good"],
+            "venue": ["東京", "東京", "東京"],
+            "race_class": ["G1", "G1", "G1"],
+            "race_date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+            "post_position": [1, 5, 10],
+            "weight_carried": [55, 56, 57]
+        })
+        
+        # テスト用過去成績データ
+        self.history_df = pd.DataFrame({
+            "horse_id": ["H001"] * 10 + ["H002"] * 10 + ["H003"] * 10,
+            "race_date": pd.date_range("2023-01-01", periods=10).tolist() * 3,
+            "finish_position": [1, 2, 3, 1, 5, 2, 3, 4, 1, 2] * 3,
+            "distance": [1600] * 30,
+            "track_condition": ["good"] * 30,
+            "venue": ["東京"] * 30,
+            "race_class": ["G1"] * 30,
+            "post_position": list(range(1, 11)) * 3,
+            "weight_carried": [55] * 30,
+            "prize_money": [10000000] * 30,
+            "race_grade": ["G1"] * 15 + ["G2"] * 15
+        })
+
+    def test_extract_past_performance_stats(self):
+        """過去成績統計特徴量の抽出テスト"""
+        result = self.extractor.extract_past_performance_stats(
+            self.df, self.history_df
+        )
+        
+        # 特徴量が追加されていることを確認
+        self.assertIn("avg_finish_position_last3", result.columns)
+        self.assertIn("median_finish_position_last5", result.columns)
+        self.assertIn("std_finish_position_last3", result.columns)
+        self.assertIn("best_finish_last5", result.columns)
+        self.assertIn("worst_finish_last5", result.columns)
+        self.assertIn("win_count_last10", result.columns)
+        self.assertIn("consistency_score", result.columns)
+        self.assertIn("recent_form_trend", result.columns)
+        
+        # 値が数値であることを確認
+        self.assertTrue(pd.api.types.is_numeric_dtype(result["avg_finish_position_last3"]))
+        
+        # 特徴量数の確認
+        self.assertEqual(self.extractor.feature_count, 15)
+
+    def test_extract_career_performance(self):
+        """生涯成績特徴量の抽出テスト"""
+        result = self.extractor.extract_career_performance(
+            self.df, self.history_df
+        )
+        
+        # 特徴量が追加されていることを確認
+        self.assertIn("career_win_rate", result.columns)
+        self.assertIn("career_place_rate", result.columns)
+        self.assertIn("career_show_rate", result.columns)
+        self.assertIn("career_starts", result.columns)
+        self.assertIn("career_earnings", result.columns)
+        self.assertIn("career_g1_wins", result.columns)
+        
+        # 勝率が0-1の範囲内であることを確認
+        self.assertTrue((result["career_win_rate"] >= 0).all())
+        self.assertTrue((result["career_win_rate"] <= 1).all())
+        
+        # 特徴量数の確認
+        self.assertEqual(self.extractor.feature_count, 8)
+
+    def test_extract_conditional_performance(self):
+        """条件別成績特徴量の抽出テスト"""
+        result = self.extractor.extract_conditional_performance(
+            self.df, self.history_df
+        )
+        
+        # 特徴量が追加されていることを確認
+        self.assertIn("distance_category_win_rate", result.columns)
+        self.assertIn("track_condition_win_rate", result.columns)
+        self.assertIn("venue_win_rate", result.columns)
+        self.assertIn("class_win_rate", result.columns)
+        self.assertIn("position_win_rate", result.columns)
+        
+        # 特徴量数の確認
+        self.assertEqual(self.extractor.feature_count, 7)
+
+    def test_extract_all_performance_features(self):
+        """全成績特徴量の統合テスト"""
+        result = self.extractor.extract_all_performance_features(
+            self.df, self.history_df, self.history_df
+        )
+        
+        # 全30個の特徴量が生成されることを確認
+        self.assertEqual(self.extractor.feature_count, 30)
+        self.assertEqual(len(self.extractor.feature_names), 30)
+        
+        # NaN値がないことを確認（デフォルト値0で埋められている）
+        for feat in self.extractor.feature_names:
+            self.assertFalse(result[feat].isna().any())
+
+
+class TestTimeFeatureExtractor(unittest.TestCase):
+    """タイム特徴量抽出器のテスト"""
+
+    def setUp(self):
+        """テストデータのセットアップ"""
+        self.extractor = TimeFeatureExtractor()
+        
+        # テスト用レースデータ
+        self.df = pd.DataFrame({
+            "race_id": ["R001", "R001", "R001"],
+            "horse_id": ["H001", "H002", "H003"],
+            "distance": [1600, 1600, 1600],
+            "track_type": ["turf", "turf", "turf"],
+            "track_condition": ["good", "good", "good"]
+        })
+        
+        # テスト用過去成績データ（タイム情報含む）
+        self.history_df = pd.DataFrame({
+            "horse_id": ["H001"] * 5 + ["H002"] * 5 + ["H003"] * 5,
+            "race_id": ["R" + str(i) for i in range(15)],
+            "race_date": pd.date_range("2023-01-01", periods=5).tolist() * 3,
+            "race_time": ["1:33.5", "1:34.0", "1:33.8", "1:34.2", "1:33.6"] * 3,
+            "last_3f": [33.5, 34.0, 33.8, 34.2, 33.6] * 3,
+            "last_3f_rank": [1, 3, 2, 4, 1] * 3,
+            "distance": [1600] * 15,
+            "track_type": ["turf"] * 15,
+            "track_condition": ["good"] * 15
+        })
+
+    def test_time_to_seconds_conversion(self):
+        """タイム文字列の秒変換テスト"""
+        # 正常なケース
+        self.assertEqual(self.extractor._time_to_seconds("1:33.5"), 93.5)
+        self.assertEqual(self.extractor._time_to_seconds("2:01.2"), 121.2)
+        
+        # エッジケース
+        self.assertEqual(self.extractor._time_to_seconds(""), 0)
+        self.assertEqual(self.extractor._time_to_seconds(None), 0)
+
+    def test_extract_race_time_features(self):
+        """走破タイム特徴量の抽出テスト"""
+        result = self.extractor.extract_race_time_features(
+            self.df, self.history_df
+        )
+        
+        # 特徴量が追加されていることを確認
+        self.assertIn("last_race_time", result.columns)
+        self.assertIn("avg_time_last3", result.columns)
+        self.assertIn("avg_time_last5", result.columns)
+        self.assertIn("best_time_at_distance", result.columns)
+        self.assertIn("time_index", result.columns)
+        self.assertIn("speed_figure", result.columns)
+        
+        # 特徴量数の確認
+        self.assertEqual(self.extractor.feature_count, 10)
+
+    def test_extract_last3f_features(self):
+        """上がり3F特徴量の抽出テスト"""
+        result = self.extractor.extract_last3f_features(
+            self.df, self.history_df
+        )
+        
+        # 特徴量が追加されていることを確認
+        self.assertIn("last_3f_time", result.columns)
+        self.assertIn("avg_last3f_last3", result.columns)
+        self.assertIn("best_last3f", result.columns)
+        self.assertIn("last3f_rank", result.columns)
+        self.assertIn("last3f_consistency", result.columns)
+        
+        # 特徴量数の確認
+        self.assertEqual(self.extractor.feature_count, 10)
+
+    def test_get_base_time(self):
+        """基準タイム取得のテスト"""
+        # 芝1600m
+        base_time = self.extractor._get_base_time(1600, "turf")
+        self.assertEqual(base_time, 94.0)
+        
+        # ダート1800m
+        base_time = self.extractor._get_base_time(1800, "dirt")
+        self.assertEqual(base_time, 110.0)
+        
+        # 中間距離の補間
+        base_time = self.extractor._get_base_time(1700, "turf")
+        self.assertTrue(94.0 < base_time < 107.0)
+
+
+class TestJockeyTrainerFeatureExtractor(unittest.TestCase):
+    """騎手・調教師特徴量抽出器のテスト"""
+
+    def setUp(self):
+        """テストデータのセットアップ"""
+        self.extractor = JockeyTrainerFeatureExtractor()
+        
+        # テスト用レースデータ
+        self.df = pd.DataFrame({
+            "race_id": ["R001", "R001", "R001"],
+            "horse_id": ["H001", "H002", "H003"],
+            "jockey_id": ["J001", "J002", "J003"],
+            "trainer_id": ["T001", "T002", "T003"],
+            "distance": [1600, 1600, 1600],
+            "venue": ["東京", "東京", "東京"],
+            "race_class": ["G1", "G1", "G1"]
+        })
+        
+        # テスト用騎手統計データ
+        self.jockey_stats = pd.DataFrame({
+            "jockey_id": ["J001"] * 20 + ["J002"] * 20 + ["J003"] * 20,
+            "race_date": pd.date_range("2023-01-01", periods=20).tolist() * 3,
+            "finish_position": ([1, 2, 3, 4, 5] * 4) * 3,
+            "distance": [1600] * 60,
+            "venue": ["東京"] * 60,
+            "race_class": ["G1"] * 60,
+            "horse_id": ["H" + str(i % 10) for i in range(60)],
+            "prize_money": [1000000] * 60
+        })
+        
+        # テスト用調教師統計データ
+        self.trainer_stats = pd.DataFrame({
+            "trainer_id": ["T001"] * 20 + ["T002"] * 20 + ["T003"] * 20,
+            "race_date": pd.date_range("2023-01-01", periods=20).tolist() * 3,
+            "finish_position": ([1, 2, 3, 4, 5] * 4) * 3,
+            "distance": [1600] * 60,
+            "venue": ["東京"] * 60,
+            "race_class": ["G1"] * 60,
+            "jockey_id": ["J" + str(i % 10) for i in range(60)],
+            "horse_id": ["H" + str(i % 10) for i in range(60)],
+            "race_grade": ["G1"] * 30 + ["G2"] * 30
+        })
+
+    def test_extract_jockey_features(self):
+        """騎手特徴量の抽出テスト"""
+        result = self.extractor.extract_jockey_features(
+            self.df, self.jockey_stats
+        )
+        
+        # 特徴量が追加されていることを確認
+        self.assertIn("jockey_win_rate", result.columns)
+        self.assertIn("jockey_place_rate", result.columns)
+        self.assertIn("jockey_show_rate", result.columns)
+        self.assertIn("jockey_venue_win_rate", result.columns)
+        self.assertIn("jockey_distance_win_rate", result.columns)
+        self.assertIn("jockey_experience_years", result.columns)
+        
+        # 勝率が0-1の範囲内であることを確認
+        self.assertTrue((result["jockey_win_rate"] >= 0).all())
+        self.assertTrue((result["jockey_win_rate"] <= 1).all())
+        
+        # 特徴量数の確認
+        self.assertEqual(self.extractor.feature_count, 10)
+
+    def test_extract_trainer_features(self):
+        """調教師特徴量の抽出テスト"""
+        result = self.extractor.extract_trainer_features(
+            self.df, self.trainer_stats
+        )
+        
+        # 特徴量が追加されていることを確認
+        self.assertIn("trainer_win_rate", result.columns)
+        self.assertIn("trainer_place_rate", result.columns)
+        self.assertIn("trainer_venue_win_rate", result.columns)
+        self.assertIn("trainer_stable_size", result.columns)
+        self.assertIn("trainer_g1_wins", result.columns)
+        
+        # 特徴量数の確認
+        self.assertEqual(self.extractor.feature_count, 10)
+
+    def test_get_distance_category(self):
+        """距離カテゴリ分類のテスト"""
+        self.assertEqual(self.extractor._get_distance_category(1200), "sprint")
+        self.assertEqual(self.extractor._get_distance_category(1600), "mile")
+        self.assertEqual(self.extractor._get_distance_category(2000), "intermediate")
+        self.assertEqual(self.extractor._get_distance_category(2400), "long")
+
+    def test_calculate_compatibility_score(self):
+        """相性スコア計算のテスト"""
+        positions = pd.Series([1, 2, 3, 4, 5])
+        score = self.extractor._calculate_compatibility_score(positions)
+        
+        # スコアが0-1の範囲内であることを確認
+        self.assertTrue(0 <= score <= 1)
+        
+        # 良い成績ほど高スコア
+        good_positions = pd.Series([1, 1, 2])
+        bad_positions = pd.Series([10, 12, 15])
+        self.assertGreater(
+            self.extractor._calculate_compatibility_score(good_positions),
+            self.extractor._calculate_compatibility_score(bad_positions)
+        )
+
+
+class TestFeatureIntegration(unittest.TestCase):
+    """特徴量抽出の統合テスト"""
+
+    def test_all_phase1_features(self):
+        """Phase1全特徴量（70個）の統合テスト"""
+        # 各抽出器のインスタンス化
+        perf_extractor = HorsePerformanceExtractor()
+        time_extractor = TimeFeatureExtractor()
+        jt_extractor = JockeyTrainerFeatureExtractor()
+        
+        # テストデータ作成
+        df = pd.DataFrame({
+            "race_id": ["R001"],
+            "horse_id": ["H001"],
+            "jockey_id": ["J001"],
+            "trainer_id": ["T001"],
+            "distance": [1600],
+            "track_type": ["turf"]
+        })
+        
+        # 各特徴量抽出
+        df = perf_extractor.extract_all_performance_features(df)
+        df = time_extractor.extract_all_time_features(df)
+        df = jt_extractor.extract_all_jockey_trainer_features(df)
+        
+        # 合計70個の特徴量が生成されることを確認
+        total_features = (
+            perf_extractor.feature_count +
+            time_extractor.feature_count +
+            jt_extractor.feature_count
+        )
+        self.assertEqual(total_features, 70)
+        
+        print(f"✅ Phase1特徴量テスト完了: 合計{total_features}個の特徴量を確認")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
競馬予想AIの特徴量エンジニアリング基盤を実装しました。
Phase1の必須特徴量100個のうち70個を実装完了。

## 実装内容

### 馬の成績特徴量（30個）
- **過去N走成績統計（15個）**: 着順平均、中央値、標準偏差、最高・最低着順など
- **生涯成績（8個）**: 勝率、連対率、複勝率、獲得賞金、G1勝利数など
- **条件別成績（7個）**: 距離別、馬場別、競馬場別、クラス別勝率など

### タイム特徴量（20個）
- **走破タイム（10個）**: 前走タイム、平均タイム、ベストタイム、スピード指数など
- **上がり3F（10個）**: 前走上がり、平均上がり、上がり順位、安定性など

### 騎手・調教師特徴量（20個）
- **騎手特徴（10個）**: 勝率、競馬場別成績、馬との相性、経験年数など
- **調教師特徴（10個）**: 勝率、騎手コンビ成績、厩舎規模、G1勝利数など

## テスト
- ✅ 単体テスト13個全て成功
- ⏱️ 実行時間: 0.128秒
- 📊 カバレッジ: Phase1実装分は100%

## 今後の予定
- [ ] Phase1残り30個（レース条件15個、血統基本15個）
- [ ] Phase2: 詳細特徴量100個
- [ ] Phase3: エンジニアリング特徴量100個

最終的に300個の特徴量で高精度な競馬予想を実現します。

🤖 Generated with [Claude Code](https://claude.ai/code)